### PR TITLE
Closes #24. Identifier modifiers and query/bang/assignment methods

### DIFF
--- a/spec/syntax/lexer_spec.cr
+++ b/spec/syntax/lexer_spec.cr
@@ -140,6 +140,15 @@ describe "Lexer" do
     token.value.should eq("hello!")
   end
 
+  it "does not allow multiple modifiers on an identifier" do
+    parser = Parser.new(IO::Memory.new(%q(hello??)), File.join(Dir.current, "_.mt"))
+    # Instantiating the parser will parse the first token.
+    token = parser.current_token
+    token.type.should eq(Token::Type::IDENT)
+    # The lexer should only accept a single modifier as part of the identifier
+    token.value.should eq("hello?")
+  end
+
   it "allows escape characters in strings" do
     assert_token_type %q("\""),   Token::Type::STRING
     assert_token_type %q("\0"),   Token::Type::STRING

--- a/spec/syntax/lexer_spec.cr
+++ b/spec/syntax/lexer_spec.cr
@@ -68,11 +68,8 @@ STATIC_TOKENS = {
   Token::Type::NIL          =>  "nil"
 }
 
-# This spec only tests simple token types. Types whose value is not static
-# (strings, identifiers, numerics, symbols, etc.) each have their own, more
-# comprehensive specs.
-describe "Lexer" do
 
+describe "Lexer" do
   {% for type, token in STATIC_TOKENS %}
     it "lexes `" + {{token}} + "`" do
       assert_token_type {{token}}, {{type}}
@@ -129,6 +126,18 @@ describe "Lexer" do
     assert_token_type %q("hello, world"), Token::Type::STRING
     assert_token_type %q("hello,
     world"),                              Token::Type::STRING
+  end
+
+  it "lexes ? as an identifier modifier" do
+    token = tokenize(%q(hello?)).first
+    token.type.should eq(Token::Type::IDENT)
+    token.value.should eq("hello?")
+  end
+
+  it "lexes ! as an identifier modifier" do
+    token = tokenize(%q(hello!)).first
+    token.type.should eq(Token::Type::IDENT)
+    token.value.should eq("hello!")
   end
 
   it "allows escape characters in strings" do

--- a/spec/syntax/parser_spec.cr
+++ b/spec/syntax/parser_spec.cr
@@ -28,12 +28,15 @@ end
 
 
 private def test_calls_with_receiver(receiver_source, receiver_node)
-  # Bare identifiers are considered calls, as long as they have not already been defined as Vars.
-  it_parses %Q(#{receiver_source}call),            Call.new(receiver_node, "call")
-  it_parses %Q(#{receiver_source}call()),          Call.new(receiver_node, "call")
-  it_parses %Q(#{receiver_source}call(1)),         Call.new(receiver_node, "call", [l(1)])
-  it_parses %Q(#{receiver_source}call(1, 2 + 3)),  Call.new(receiver_node, "call", [l(1), Call.new(l(2), "+", [l(3)], infix: true)])
-  it_parses %Q(#{receiver_source}call (1)),        Call.new(receiver_node, "call", [l(1)])
+  it_parses %Q(#{receiver_source}call),             Call.new(receiver_node, "call")
+  it_parses %Q(#{receiver_source}call?),            Call.new(receiver_node, "call?")
+  it_parses %Q(#{receiver_source}call!),            Call.new(receiver_node, "call!")
+  it_parses %Q(#{receiver_source}call()),           Call.new(receiver_node, "call")
+  it_parses %Q(#{receiver_source}call?()),          Call.new(receiver_node, "call?")
+  it_parses %Q(#{receiver_source}call!()),          Call.new(receiver_node, "call!")
+  it_parses %Q(#{receiver_source}call(1)),          Call.new(receiver_node, "call", [l(1)])
+  it_parses %Q(#{receiver_source}call(1, 2 + 3)),   Call.new(receiver_node, "call", [l(1), Call.new(l(2), "+", [l(3)], infix: true)])
+  it_parses %Q(#{receiver_source}call (1)),         Call.new(receiver_node, "call", [l(1)])
   it_parses %Q(
     #{receiver_source}call(
       1,
@@ -60,12 +63,16 @@ private def test_calls_with_receiver(receiver_source, receiver_node)
   ),                              Call.new(receiver_node, "call", block: Block.new)
 
   # The `do...end` syntax can also have a delimiter after the `do` and parameters.
-  it_parses %Q(#{receiver_source}call do; end),     Call.new(receiver_node, "call", block: Block.new)
-  it_parses %Q(#{receiver_source}call   do; end),   Call.new(receiver_node, "call", block: Block.new)
-  it_parses %Q(#{receiver_source}call do |a|; end), Call.new(receiver_node, "call", block: Block.new([p("a")]))
+  it_parses %Q(#{receiver_source}call do; end),       Call.new(receiver_node, "call",   block: Block.new)
+  it_parses %Q(#{receiver_source}call? do; end),      Call.new(receiver_node, "call?",  block: Block.new)
+  it_parses %Q(#{receiver_source}call! do; end),      Call.new(receiver_node, "call!",  block: Block.new)
+  it_parses %Q(#{receiver_source}call   do; end),     Call.new(receiver_node, "call",   block: Block.new)
+  it_parses %Q(#{receiver_source}call do |a|; end),   Call.new(receiver_node, "call",   block: Block.new([p("a")]))
 
   # Brace blocks accept arguments after the opening brace.
-  it_parses %Q(#{receiver_source}call{ |a,b| }),                  Call.new(receiver_node, "call", block: Block.new([p("a"), p("b")]))
+  it_parses %Q(#{receiver_source}call{ |a,b| }),                  Call.new(receiver_node, "call",   block: Block.new([p("a"), p("b")]))
+  it_parses %Q(#{receiver_source}call?{ |a,b| }),                 Call.new(receiver_node, "call?",  block: Block.new([p("a"), p("b")]))
+  it_parses %Q(#{receiver_source}call!{ |a,b| }),                 Call.new(receiver_node, "call!",  block: Block.new([p("a"), p("b")]))
   # Block parameters are exactly like normal Def parameters, with the same syntax support.
   it_parses %Q(#{receiver_source}call{ | | }),                    Call.new(receiver_node, "call", block: Block.new())
   it_parses %Q(#{receiver_source}call{ |a,*b| }),                 Call.new(receiver_node, "call", block: Block.new([p("a"), p("b", splat: true)]))
@@ -249,8 +256,12 @@ describe "Parser" do
   it_parses %q(<[1, 2]>),       i([1, 2])
   it_parses %q(<[a, *b]>),      i(l([Call.new(nil, "a"), Splat.new(Call.new(nil, "b"))]))
   it_parses %q(<{a: 1}>),       i({:a => 1})
+  # Interpolations are valid as receivers for Calls
+  test_calls_with_receiver("<a>.",  i(Call.new(nil, "a")))
   # Calls, Vars, Consts, Underscores are also valid.
   it_parses %q(<a>),            i(Call.new(nil, "a"))
+  it_parses %q(<a?>),           i(Call.new(nil, "a?"))
+  it_parses %q(<a!>),           i(Call.new(nil, "a!"))
   it_parses %q(<a(1, 2)>),      i(Call.new(nil, "a", [l(1), l(2)]))
   it_parses %q(<a.b(1)>),       i(Call.new(Call.new(nil, "a"), "b", [l(1)]))
   it_parses %q(<a.b.c>),        i(Call.new(Call.new(Call.new(nil, "a"), "b"), "c"))
@@ -1026,6 +1037,8 @@ describe "Parser" do
 
   test_calls_with_receiver("",                  nil)
   test_calls_with_receiver("object.",           Call.new(nil, "object"))
+  test_calls_with_receiver("object?.",          Call.new(nil, "object?"))
+  test_calls_with_receiver("object!.",          Call.new(nil, "object!"))
   test_calls_with_receiver("nested.object.",    Call.new(Call.new(nil, "nested"), "object"))
   test_calls_with_receiver("Thing.member.",     Call.new(c("Thing"), "member"))
   test_calls_with_receiver("Thing.Other.",      Call.new(c("Thing"), "Other"))

--- a/spec/syntax/parser_spec.cr
+++ b/spec/syntax/parser_spec.cr
@@ -433,9 +433,13 @@ describe "Parser" do
   it_parses %q(_ = 2),      SimpleAssign.new(u("_"), l(2))
   # The left hand side may also be a Call expression as long as the Call has a receiver.
   it_parses %q(a.b = 1),          SimpleAssign.new(Call.new(Call.new(nil, "a"), "b"), l(1))
+  it_parses %q(a.b.c = 1),        SimpleAssign.new(Call.new(Call.new(Call.new(nil, "a"), "b"), "c"), l(1))
   it_parses %q(a[0] = 1),         SimpleAssign.new(Call.new(Call.new(nil, "a"), "[]", [l(0)]), l(1))
   it_parses %q(a.b = c.d = 1),    SimpleAssign.new(Call.new(Call.new(nil, "a"), "b"), SimpleAssign.new(Call.new(Call.new(nil, "c"), "d"), l(1)).as(Node))
   it_parses %q(a[0] = b[0] = 1),  SimpleAssign.new(Call.new(Call.new(nil, "a"), "[]", [l(0)]), SimpleAssign.new(Call.new(Call.new(nil, "b"), "[]", [l(0)]), l(1)).as(Node))
+  # Assignments are not allowed to methods with modifiers
+  it_does_not_parse %q(a.b? = 1)
+  it_does_not_parse %q(a.b! = 1)
 
   # Assignments can not be made to literal values.
   it_does_not_parse %q(2 = 4),          /cannot assign to literal value/i
@@ -645,6 +649,21 @@ describe "Parser" do
   ),                          Def.new("foo") # `@body` will be a Nop
   # Semicolons can be used as delimiters to compact the definition.
   it_parses %q(def foo; end), Def.new("foo")
+
+  # Any identifier is valid as a definition name
+  it_parses %q(def foo_;  end), Def.new("foo_")
+  it_parses %q(def _foo;  end), Def.new("_foo")
+  it_parses %q(def foo?;  end), Def.new("foo?")
+  it_parses %q(def foo!;  end), Def.new("foo!")
+  it_parses %q(def foo_!; end), Def.new("foo_!")
+  it_parses %q(def foo_?; end), Def.new("foo_?")
+
+  # `=` can also be appended to any non-modified identifier.
+  it_parses %q(def foo=;    end), Def.new("foo=")
+  it_parses %q(def foo_=(); end), Def.new("foo_=")
+  it_parses %q(def _foo=(); end), Def.new("_foo=")
+  it_does_not_parse %q(def foo?=; end)
+  it_does_not_parse %q(def foo!=; end)
 
   it_parses %q(
     def foo(a, b)

--- a/spec/syntax/parser_spec.cr
+++ b/spec/syntax/parser_spec.cr
@@ -443,11 +443,11 @@ describe "Parser" do
   it_parses %q(THING = 4),  SimpleAssign.new(c("THING"), l(4))
   it_parses %q(_ = 2),      SimpleAssign.new(u("_"), l(2))
   # The left hand side may also be a Call expression as long as the Call has a receiver.
-  it_parses %q(a.b = 1),          SimpleAssign.new(Call.new(Call.new(nil, "a"), "b"), l(1))
-  it_parses %q(a.b.c = 1),        SimpleAssign.new(Call.new(Call.new(Call.new(nil, "a"), "b"), "c"), l(1))
-  it_parses %q(a[0] = 1),         SimpleAssign.new(Call.new(Call.new(nil, "a"), "[]", [l(0)]), l(1))
-  it_parses %q(a.b = c.d = 1),    SimpleAssign.new(Call.new(Call.new(nil, "a"), "b"), SimpleAssign.new(Call.new(Call.new(nil, "c"), "d"), l(1)).as(Node))
-  it_parses %q(a[0] = b[0] = 1),  SimpleAssign.new(Call.new(Call.new(nil, "a"), "[]", [l(0)]), SimpleAssign.new(Call.new(Call.new(nil, "b"), "[]", [l(0)]), l(1)).as(Node))
+  it_parses %q(a.b = 1),          Call.new(Call.new(nil, "a"), "b=", [l(1)])
+  it_parses %q(a.b.c = 1),        Call.new(Call.new(Call.new(nil, "a"), "b"), "c=", [l(1)])
+  it_parses %q(a[0] = 1),         Call.new(Call.new(nil, "a"), "[]=", [l(0), l(1)])
+  it_parses %q(a.b = c.d = 1),    Call.new(Call.new(nil, "a"), "b=", [Call.new(Call.new(nil, "c"), "d=", [l(1)]).as(Node)])
+  it_parses %q(a[0] = b[0] = 1),  Call.new(Call.new(nil, "a"), "[]=", [l(0), Call.new(Call.new(nil, "b"), "[]=", [l(0), l(1)]).as(Node)])
   # Assignments are not allowed to methods with modifiers
   it_does_not_parse %q(a.b? = 1)
   it_does_not_parse %q(a.b! = 1)
@@ -673,8 +673,10 @@ describe "Parser" do
   it_parses %q(def foo=;    end), Def.new("foo=")
   it_parses %q(def foo_=(); end), Def.new("foo_=")
   it_parses %q(def _foo=(); end), Def.new("_foo=")
+  # Multiple modifiers are not allowed
   it_does_not_parse %q(def foo?=; end)
   it_does_not_parse %q(def foo!=; end)
+
 
   it_parses %q(
     def foo(a, b)

--- a/src/myst/syntax/lexer.cr
+++ b/src/myst/syntax/lexer.cr
@@ -399,6 +399,12 @@ module Myst
         end
       end
 
+      # Identifiers may end with a query (`?`) or bang (`!`) modifier as the
+      # last character.
+      if current_char == '?' || current_char == '!'
+        read_char
+      end
+
       @current_token.value = @reader.buffer_value
     end
   end


### PR DESCRIPTION
See #24 for more details. This PR allows all identifiers to be followed by modifiers (`?` or `!`). Additionally, in method definitions, a _non-modified_ identifier can be followed by an `=` to create an "assignment method". These are calls that the parser automatically infers from simple assignments with `Call`s as the left-hand side.

For example, `a.b = c` is re-written by the parser to be a Call on `a` to the method `b=`, with the argument `c`. This also applies to access notation, where a Call in the form `a[b] = c` is re-written to a Call on `a` to the method `[]=` with the arguments, `b, c`.