### PR TITLE
Closes #27. Operator methods

### DIFF
--- a/spec/interpreter/nodes/call_spec.cr
+++ b/spec/interpreter/nodes/call_spec.cr
@@ -91,6 +91,30 @@ describe "Interpreter - Call" do
       f3 = f1 #{op} f2
       f3.a
     ),              [val(3)]
+
+    # Operators can also be defined statically to do some type algebra.
+    it_interprets %Q(
+      deftype Foo
+        defstatic #{op}(other : Foo)
+          :called_op_on_type
+        end
+      end
+
+      Foo #{op} Foo
+    ),              [val(:called_op_on_type)]
+
+    # Or on modules, for whatever that might be worth... (I guess this could
+    # define operators in a module that could be included? Not sure why it
+    # would be done outside of an `include`, though).
+    it_interprets %Q(
+      defmodule Foo
+        def #{op}(other)
+          :called_op_on_module
+        end
+      end
+
+      Foo #{op} Foo
+    ),              [val(:called_op_on_module)]
   end
 
   # Access and access assignment can also be overloaded.

--- a/spec/interpreter/nodes/call_spec.cr
+++ b/spec/interpreter/nodes/call_spec.cr
@@ -66,6 +66,56 @@ describe "Interpreter - Call" do
     Foo.a? + Foo.b!
   ),              [val(3)]
 
+  # Operators can be overloaded by defining a method with the operator as the
+  # name on an object.
+  # The match operator overload will have special semantics. These are TBD from
+  # https://github.com/myst-lang/myst/issues/11.
+  [
+    "+", "-", "*", "/", "%",
+    "<", "<=", "!=", "==", ">=", ">"
+  ].each do |op|
+    it_interprets %Q(
+      deftype Foo
+        def a; @a; end
+        def initialize(a)
+          @a = a
+        end
+
+        def #{op}(other : Foo)
+          %Foo{@a + other.a}
+        end
+      end
+
+      f1 = %Foo{1}
+      f2 = %Foo{2}
+      f3 = f1 #{op} f2
+      f3.a
+    ),              [val(3)]
+  end
+
+  # Access and access assignment can also be overloaded.
+  it_interprets %q(
+    deftype Foo
+      def initialize
+        @values = [1, 2, 3]
+      end
+
+      def [](idx : Integer)
+        @values[idx]
+      end
+
+      def []=(idx : Integer, value)
+        @values[idx] = value
+      end
+
+      def values; @values; end
+    end
+
+    f1 = %Foo{}
+    f1[2] = 5
+    f1.values
+  ),                [val([1, 2, 5])]
+
 
   # When looking up a function, the current lexical scope should be checked for
   # overrides. However, parent lexical scopes should be ignored.

--- a/spec/syntax/parser_spec.cr
+++ b/spec/syntax/parser_spec.cr
@@ -844,6 +844,16 @@ describe "Parser" do
     end
   ),                            Def.new("foo", [p("list", l([1, u("_")]), restriction: c("List")), p(nil, l(nil)), p("b", restriction: c("Integer"))])
 
+  # Some operators are also allowed as method names for overloading.
+  [
+    "+", "-", "*", "/", "%", "[]", "[]=",
+    "<", "<=", "!=", "==", ">=", ">"
+  ].each do |op|
+    it_parses %Q(def #{op}; end),         Def.new(op)
+    it_parses %Q(def #{op}(); end),       Def.new(op)
+    it_parses %Q(def #{op}(other); end),  Def.new(op, [p("other")])
+    it_parses %Q(def #{op}(a, b); end),   Def.new(op, [p("a"), p("b")])
+  end
 
 
   # Module definitions

--- a/src/myst/interpreter/native_lib/list.cr
+++ b/src/myst/interpreter/native_lib/list.cr
@@ -18,6 +18,10 @@ module Myst
       this.elements[index.value]
     end
 
+    NativeLib.method :list_access_assign, TList, index : TInteger, value : Value do
+      this.elements[index.value] = value
+    end
+
 
     def init_list(root_scope : Scope)
       list_type = TType.new("List", root_scope)
@@ -26,6 +30,7 @@ module Myst
       NativeLib.def_instance_method(list_type, :each, :list_each)
       NativeLib.def_instance_method(list_type, :+,    :list_add)
       NativeLib.def_instance_method(list_type, :[],   :list_access)
+      NativeLib.def_instance_method(list_type, :[]=,  :list_access_assign)
 
       list_type
     end

--- a/src/myst/syntax/token.cr
+++ b/src/myst/syntax/token.cr
@@ -167,8 +167,13 @@ module Myst
       end
 
       def self.binary_operators
-        [ PLUS, MINUS, STAR, SLASH, EQUAL, MATCH, LESS, LESSEQUAL,
+        [ PLUS, MINUS, STAR, SLASH, MODULO, EQUAL, MATCH, LESS, LESSEQUAL,
           GREATEREQUAL, GREATER, NOTEQUAL, EQUALEQUAL, ANDAND, OROR]
+      end
+
+      def self.overloadable_operators
+        [ PLUS, MINUS, STAR, SLASH, MODULO, MATCH, LESS, LESSEQUAL,
+          NOTEQUAL, EQUALEQUAL, GREATEREQUAL, GREATER]
       end
 
       def unary_operator?
@@ -177,6 +182,10 @@ module Myst
 
       def binary_operator?
         self.class.binary_operators.includes?(self)
+      end
+
+      def overloadable_operator?
+        self.class.overloadable_operators.includes?(self)
       end
 
       def operator?


### PR DESCRIPTION
Most operators are now allowed as method names. The supported list is: `+`, `-`, `*`, `/`, `%`,
`<`, `<=`, `!=`, `==`, `>=`, `>`, `[]`, and `[]=`. The last two are not operators that are recognized by the lexer, but rather operators that the parser infers from the access and access assignment syntaxes.

An interesting effect of the implementation is that the operators can be defined statically or on modules and still have the same effects:

```myst
 deftype Foo
  defstatic +(other)
    :called_op_on_type
  end
end

Foo + Foo #=> :called_op_on_type
```

This has the potential of being used for some type algebra and/or metaprogramming. I don't really understand the extend of what it could do, but I'm glad it works nonetheless.