### PR TITLE
Fixes #37. Lookup Constants in both static and instance scopes.

### DIFF
--- a/spec/interpreter/nodes/instantiation_spec.cr
+++ b/spec/interpreter/nodes/instantiation_spec.cr
@@ -178,4 +178,22 @@ describe "Interpreter - Instantiation" do
     result = itr.stack.pop
     result.should eq(val(["hello", :nil]))
   end
+
+  it "can find sibling types from instance scopes (GitHub issue #37)" do
+    itr = interpret_with_mocked_output %q(
+      deftype Foo
+        deftype Bar
+        end
+
+        def foo
+          %Bar{}
+        end
+      end
+
+      instance  = %Foo{}.foo
+    )
+
+    itr.errput.to_s.should eq("")
+    itr.__typeof(itr.current_scope["instance"]).name.should eq("Bar")
+  end
 end

--- a/src/myst/interpreter/nodes/references.cr
+++ b/src/myst/interpreter/nodes/references.cr
@@ -20,7 +20,12 @@ module Myst
     end
 
     def visit(node : Const)
-      stack.push(lookup(node))
+      if value = current_scope[node.name]? || __typeof(current_self).scope[node.name]
+        stack.push(value)
+      else
+        @callstack.push(node)
+        raise_not_found(node.name, current_self)
+      end
     end
 
     def visit(node : Underscore)


### PR DESCRIPTION
References to Constants can be done from both static and instance scopes. Until now, the lookup was always naively being performed on the `current_scope`, which could be either static or instance, but both would not be checked.

This led to the bug described in #37, where the `current_scope` was the scope of an instance, while the constant was defined on the static scope of `current_self`. In this case, the constant should have been resolved, but wasn't because only the instance scope was being checked.

An example of this behavior is

```myst
deftype Foo
  deftype Bar
  end

  def make_bar
    %Bar{}
  end
end

# `instance` should become an instance of `Foo.Bar`.
instance  = %Foo{}.make_bar
```

An interesting observation is that if `Bar` was defined _outside_ of `Foo`, this bug would not occur, because both static and instance scopes have their parent set to the lexical scope they are defined in, and in that case `Bar` would have been defined in that lexical scope. In this case, however, `Bar` is defined on the static scope of `Foo`.

This behavior of lexical scoping might change in the future, where instance scopes won't see their lexical scope, but shouldn't cause issues beyond this.