### PR TITLE
Closes #31. Implement a basic Spec library

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,9 @@
 language: crystal
+
+install:
+  # Ensure that the build will be executable
+  - crystal build src/myst.cr
+
+script:
+  - crystal spec
+  - ./myst ./spec/myst/spec.mt

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,3 @@
 language: crystal
 
-install:
-  # Ensure that the build will be executable
-  - crystal build src/myst.cr
-
-script:
-  - crystal spec
-  - ./myst ./spec/myst/spec.mt
+script: make spec

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+.PHONY: spec
+spec:
+	crystal spec
+	crystal run src/myst.cr -- spec/myst/spec.mt

--- a/spec/interpreter/native_lib/integer_methods_spec.cr
+++ b/spec/interpreter/native_lib/integer_methods_spec.cr
@@ -3,33 +3,35 @@ require "../../support/interpret.cr"
 
 
 describe "NativeLib - Integer Methods" do
-  describe "#+" do
-    it_interprets %q(1 + 1),        [val(2)]
-    it_interprets %q(1 + 1 + 1),    [val(3)]
+  # These specs have been moved into `spec/myst/integer_spec.mt`. They will be
+  # completely removed after the rest of this file has been ported as well.
+  # describe "#+" do
+  #   it_interprets %q(1 + 1),        [val(2)]
+  #   it_interprets %q(1 + 1 + 1),    [val(3)]
 
-    it_interprets %q(10_000 + 100_000),               [val(110_000)]
-    it_interprets %q(1234567890 + 987654310),         [val(2_222_222_200)]
-    # Additions around max int wrap around to negatives.
-    it_interprets %q(9_223_372_036_854_775_807 + 1),  [val(-9_223_372_036_854_775_808)]
+  #   it_interprets %q(10_000 + 100_000),               [val(110_000)]
+  #   it_interprets %q(1234567890 + 987654310),         [val(2_222_222_200)]
+  #   # Additions around max int wrap around to negatives.
+  #   it_interprets %q(9_223_372_036_854_775_807 + 1),  [val(-9_223_372_036_854_775_808)]
 
-    # Addition with 0 does nothing
-    it_interprets %q(0 + 100),      [val(100)]
-    it_interprets %q(100 + 0),      [val(100)]
-    it_interprets %q(10 + 0 + 10),  [val( 20)]
-    it_interprets %q(0 + 100 + 0),  [val(100)]
+  #   # Addition with 0 does nothing
+  #   it_interprets %q(0 + 100),      [val(100)]
+  #   it_interprets %q(100 + 0),      [val(100)]
+  #   it_interprets %q(10 + 0 + 10),  [val( 20)]
+  #   it_interprets %q(0 + 100 + 0),  [val(100)]
 
-    # Addition with floats will always return a float.
-    it_interprets %q(1 + 1.0),      [val(2.0)]
-    it_interprets %q(123 + 12_396_851_265_129.468), [val(12_396_851_265_252.468)]
+  #   # Addition with floats will always return a float.
+  #   it_interprets %q(1 + 1.0),      [val(2.0)]
+  #   it_interprets %q(123 + 12_396_851_265_129.468), [val(12_396_851_265_252.468)]
 
-    # Addition with any other type is not supported
-    it_does_not_interpret %q(1 + nil),  /invalid argument/
-    it_does_not_interpret %q(1 + true), /invalid argument/
-    it_does_not_interpret %q(1 + []),   /invalid argument/
-    it_does_not_interpret %q(1 + {}),   /invalid argument/
-    it_does_not_interpret %q(1 + "a"),  /invalid argument/
-    it_does_not_interpret %q(1 + :hi),  /invalid argument/
-  end
+  #   # Addition with any other type is not supported
+  #   it_does_not_interpret %q(1 + nil),  /invalid argument/
+  #   it_does_not_interpret %q(1 + true), /invalid argument/
+  #   it_does_not_interpret %q(1 + []),   /invalid argument/
+  #   it_does_not_interpret %q(1 + {}),   /invalid argument/
+  #   it_does_not_interpret %q(1 + "a"),  /invalid argument/
+  #   it_does_not_interpret %q(1 + :hi),  /invalid argument/
+  # end
 
 
   describe "#-" do

--- a/spec/myst/integer_spec.mt
+++ b/spec/myst/integer_spec.mt
@@ -1,7 +1,9 @@
 require "stdlib/spec.mt"
 
-Spec.describe("Integer") do
+describe("Integer") do
   it("does addition") do
     assert(1 + 1 == 2)
+    assert(2 + 2 == 4)
+    assert(2_000 + 4_567 == 6_566)
   end
 end

--- a/spec/myst/integer_spec.mt
+++ b/spec/myst/integer_spec.mt
@@ -1,9 +1,70 @@
 require "stdlib/spec.mt"
 
-describe("Integer") do
-  it("does addition") do
+describe("Integer#+") do
+  it("does simple addition") do
     assert(1 + 1 == 2)
     assert(2 + 2 == 4)
-    assert(2_000 + 4_567 == 6_566)
   end
+
+  it("does chained addition") do
+    assert(1 + 1 + 1 == 3)
+    assert(1 + 2 + 3 == 4 + 2)
+  end
+
+  it("does large addition") do
+    assert(2_000 + 4_567 == 6_567)
+    assert(10_000 + 100_000 == 110_000)
+    assert(1234567890 + 987654310 == 2_222_222_200)
+  end
+
+  # TODO: revisit when Negations are supported
+  # it("wraps around max int to negatives") do
+  #   assert(9_223_372_036_854_775_807 + 1 == -9_223_372_036_854_775_808)
+  # end
+
+  it("does nothing with 0") do
+    assert(0 + 100 == 100)
+    assert(100 + 0 == 100)
+    assert(10 + 0 + 10 ==  20)
+    assert(0 + 100 + 0 == 100)
+  end
+
+  it("returns a float when given a float operand") do
+    assert(1 + 1.0 == 2.0)
+    assert(123 + 12_396_851_265_129.468 == 12_396_851_265_252.468)
+  end
+
+  it("works with variables as arguments") do
+    a = 1
+    b = 2
+    assert(a + b == 3)
+  end
+
+  # TODO: something is currently causing the value of `self` to change beyond
+  # the first call to `expect_raises`. Likely that the value is not popped.
+  #it("does not accept nil as an operand") do
+  #  expect_raises{ 1 + nil }
+  #end
+  #
+  #it("does not accept a boolean as an operand") do
+  #  expect_raises{ 1 + true }
+  #end
+  #
+  #it("does not accept a list as an operand") do
+  #  expect_raises{ 1 + [] }
+  #  expect_raises{ 1 + [1, 2] }
+  #end
+  #
+  #it("does not accept a map as an operand") do
+  #  expect_raises{ 1 + {} }
+  #  expect_raises{ 1 + {a: 1} }
+  #end
+  #
+  #it("does not accept a string as an operand") do
+  #  expect_raises{ 1 + "a" }
+  #end
+  #
+  #it("does not accept a symbol as an operand") do
+  #  expect_raises{ 1 + :hi }
+  #end
 end

--- a/spec/myst/integer_spec.mt
+++ b/spec/myst/integer_spec.mt
@@ -1,0 +1,7 @@
+require "stdlib/spec.mt"
+
+Spec.describe("Integer") do
+  it("does addition") do
+    assert(1 + 1 == 2)
+  end
+end

--- a/spec/myst/integer_spec.mt
+++ b/spec/myst/integer_spec.mt
@@ -40,31 +40,29 @@ describe("Integer#+") do
     assert(a + b == 3)
   end
 
-  # TODO: something is currently causing the value of `self` to change beyond
-  # the first call to `expect_raises`. Likely that the value is not popped.
-  #it("does not accept nil as an operand") do
-  #  expect_raises{ 1 + nil }
-  #end
-  #
-  #it("does not accept a boolean as an operand") do
-  #  expect_raises{ 1 + true }
-  #end
-  #
-  #it("does not accept a list as an operand") do
-  #  expect_raises{ 1 + [] }
-  #  expect_raises{ 1 + [1, 2] }
-  #end
-  #
-  #it("does not accept a map as an operand") do
-  #  expect_raises{ 1 + {} }
-  #  expect_raises{ 1 + {a: 1} }
-  #end
-  #
-  #it("does not accept a string as an operand") do
-  #  expect_raises{ 1 + "a" }
-  #end
-  #
-  #it("does not accept a symbol as an operand") do
-  #  expect_raises{ 1 + :hi }
-  #end
+  it("does not accept nil as an operand") do
+    expect_raises{ 1 + nil }
+  end
+
+  it("does not accept a boolean as an operand") do
+    expect_raises{ 1 + true }
+  end
+
+  it("does not accept a list as an operand") do
+    expect_raises{ 1 + [] }
+    expect_raises{ 1 + [1, 2] }
+  end
+
+  it("does not accept a map as an operand") do
+    expect_raises{ 1 + {} }
+    expect_raises{ 1 + {a: 1} }
+  end
+
+  it("does not accept a string as an operand") do
+    expect_raises{ 1 + "a" }
+  end
+
+  it("does not accept a symbol as an operand") do
+    expect_raises{ 1 + :hi }
+  end
 end

--- a/spec/myst/spec.mt
+++ b/spec/myst/spec.mt
@@ -1,0 +1,11 @@
+require "stdlib/spec.mt"
+
+include Spec
+
+# TODO: add Dir globbing to automatically detect and require all `*_spec.mt`
+# files under this directory.
+require "./integer_spec.mt"
+
+# The only way to reach this point is if all of the Specs passed. Any failures
+# will immediately exit the program, so reaching here implies success.
+IO.puts("\nAll in-language specs passed.")

--- a/src/myst/interpreter/kernel.cr
+++ b/src/myst/interpreter/kernel.cr
@@ -3,22 +3,18 @@ module Myst
     def create_kernel : TModule
       kernel = TModule.new("Kernel")
       kernel.scope.clear
-      root_scope = kernel.scope
-      kernel.scope["Nil"]       = init_nil(root_scope)
-      kernel.scope["Boolean"]   = init_boolean(root_scope)
-      kernel.scope["Integer"]   = init_integer(root_scope)
-      kernel.scope["Float"]     = init_float(root_scope)
-      kernel.scope["String"]    = init_string(root_scope)
-      kernel.scope["Symbol"]    = init_symbol(root_scope)
-      kernel.scope["List"]      = init_list(root_scope)
-      kernel.scope["Map"]       = init_map(root_scope)
-      kernel.scope["IO"]        = init_io(root_scope)
-      kernel.scope["FSUtils"]   = init_file_utils(root_scope)
-      # kernel.scope["Functor"]     = FUNCTOR_TYPE
-      # kernel.scope["FunctorDef"]  = FUNCTOR_DEF_TYPE
-      # kernel.scope["NativeDef"]   = NATIVE_DEF_TYPE
-      # kernel.scope["Module"]      = MODULE_TYPE
-      # kernel.scope["Type"]        = TYPE_TYPE
+      kernel = init_top_level(kernel)
+      kernel.scope["Kernel"]    = kernel
+      kernel.scope["Nil"]       = init_nil(kernel)
+      kernel.scope["Boolean"]   = init_boolean(kernel)
+      kernel.scope["Integer"]   = init_integer(kernel)
+      kernel.scope["Float"]     = init_float(kernel)
+      kernel.scope["String"]    = init_string(kernel)
+      kernel.scope["Symbol"]    = init_symbol(kernel)
+      kernel.scope["List"]      = init_list(kernel)
+      kernel.scope["Map"]       = init_map(kernel)
+      kernel.scope["IO"]        = init_io(kernel)
+      kernel.scope["FSUtils"]   = init_file_utils(kernel)
       kernel
     end
   end

--- a/src/myst/interpreter/native_lib.cr
+++ b/src/myst/interpreter/native_lib.cr
@@ -22,7 +22,7 @@ module Myst
         this = this.as({{this_type}})
 
         {% for type, index in params %}
-          {{params[index].var}} = __args[{{index}}].as({{params[index].type}})
+          {{params[index].var}} = __args[{{index}}]?.as({{params[index].type}})
         {% end %}
 
         result = begin

--- a/src/myst/interpreter/native_lib.cr
+++ b/src/myst/interpreter/native_lib.cr
@@ -17,6 +17,11 @@ module Myst
       Invocation.new(itr, func, receiver, args, nil).invoke
     end
 
+    # Return a RuntimeError with the given string as the value.
+    def error(message : String, trace : Callstack)
+      RuntimeError.new(TString.new(message), trace)
+    end
+
     macro method(name, this_type, *params, &block)
       def {{name.id}}(this : Value, __args : Array(Value), block : TFunctor?) : Value
         this = this.as({{this_type}})

--- a/src/myst/interpreter/native_lib/boolean.cr
+++ b/src/myst/interpreter/native_lib/boolean.cr
@@ -23,8 +23,8 @@ module Myst
     end
 
 
-    def init_boolean(root_scope : Scope)
-      boolean_type = TType.new("Boolean", root_scope)
+    def init_boolean(kernel : TModule)
+      boolean_type = TType.new("Boolean", kernel.scope)
       boolean_type.instance_scope["type"] = boolean_type
 
       NativeLib.def_instance_method(boolean_type, :to_s,  :bool_to_s)

--- a/src/myst/interpreter/native_lib/file_utils.cr
+++ b/src/myst/interpreter/native_lib/file_utils.cr
@@ -39,8 +39,8 @@ module Myst
     end
 
 
-    def init_file_utils(root_scope : Scope)
-      fs_utils_module = TModule.new("FSUtils", root_scope)
+    def init_file_utils(kernel : TModule)
+      fs_utils_module = TModule.new("FSUtils", kernel.scope)
 
       NativeLib.def_method(fs_utils_module, :open,      :fs_utils_open)
       NativeLib.def_method(fs_utils_module, :close,     :fs_utils_close)

--- a/src/myst/interpreter/native_lib/float.cr
+++ b/src/myst/interpreter/native_lib/float.cr
@@ -70,8 +70,8 @@ module Myst
     end
 
 
-    def init_float(root_scope : Scope)
-      float_type = TType.new("Float", root_scope)
+    def init_float(kernel : TModule)
+      float_type = TType.new("Float", kernel.scope)
       float_type.instance_scope["type"] = float_type
 
       NativeLib.def_instance_method(float_type, :+,     :float_add)

--- a/src/myst/interpreter/native_lib/integer.cr
+++ b/src/myst/interpreter/native_lib/integer.cr
@@ -7,7 +7,7 @@ module Myst
       when TFloat
         TFloat.new(this.value + other.value)
       else
-        raise "invalid argument for Integer#+: #{__typeof(other).name}"
+        raise NativeLib.error("invalid argument for Integer#+: #{__typeof(other).name}", callstack)
       end
     end
 

--- a/src/myst/interpreter/native_lib/integer.cr
+++ b/src/myst/interpreter/native_lib/integer.cr
@@ -82,8 +82,8 @@ module Myst
     end
 
 
-    def init_integer(root_scope : Scope)
-      integer_type = TType.new("Integer", root_scope)
+    def init_integer(kernel : TModule)
+      integer_type = TType.new("Integer", kernel.scope)
       integer_type.instance_scope["type"] = integer_type
 
       NativeLib.def_instance_method(integer_type, :+,     :int_add)

--- a/src/myst/interpreter/native_lib/io.cr
+++ b/src/myst/interpreter/native_lib/io.cr
@@ -18,8 +18,8 @@ module Myst
     end
 
 
-    def init_io(root_scope : Scope)
-      io_module = TModule.new("IO", root_scope)
+    def init_io(kernel : TModule)
+      io_module = TModule.new("IO", kernel.scope)
 
       NativeLib.def_method(io_module, :puts, :io_puts)
 

--- a/src/myst/interpreter/native_lib/list.cr
+++ b/src/myst/interpreter/native_lib/list.cr
@@ -23,8 +23,8 @@ module Myst
     end
 
 
-    def init_list(root_scope : Scope)
-      list_type = TType.new("List", root_scope)
+    def init_list(kernel : TModule)
+      list_type = TType.new("List", kernel.scope)
       list_type.instance_scope["type"] = list_type
 
       NativeLib.def_instance_method(list_type, :each, :list_each)

--- a/src/myst/interpreter/native_lib/map.cr
+++ b/src/myst/interpreter/native_lib/map.cr
@@ -11,8 +11,8 @@ module Myst
     end
 
 
-    def init_map(root_scope : Scope)
-      map_type = TType.new("Map", root_scope)
+    def init_map(kernel : TModule)
+      map_type = TType.new("Map", kernel.scope)
       map_type.instance_scope["type"] = map_type
 
       NativeLib.def_instance_method(map_type, :each, :map_each)

--- a/src/myst/interpreter/native_lib/nil.cr
+++ b/src/myst/interpreter/native_lib/nil.cr
@@ -23,8 +23,8 @@ module Myst
     end
 
 
-    def init_nil(root_scope : Scope)
-      nil_type = TType.new("Nil", root_scope)
+    def init_nil(kernel : TModule)
+      nil_type = TType.new("Nil", kernel.scope)
       nil_type.instance_scope["type"] = nil_type
 
       NativeLib.def_instance_method(nil_type, :to_s,  :nil_to_s)

--- a/src/myst/interpreter/native_lib/string.cr
+++ b/src/myst/interpreter/native_lib/string.cr
@@ -58,8 +58,8 @@ module Myst
     end
 
 
-    def init_string(root_scope : Scope)
-      string_type = TType.new("String", root_scope)
+    def init_string(kernel : TModule)
+      string_type = TType.new("String", kernel.scope)
       string_type.instance_scope["type"] = string_type
 
       NativeLib.def_instance_method(string_type, :+,      :string_add)

--- a/src/myst/interpreter/native_lib/symbol.cr
+++ b/src/myst/interpreter/native_lib/symbol.cr
@@ -23,8 +23,8 @@ module Myst
     end
 
 
-    def init_symbol(root_scope : Scope)
-      symbol_type = TType.new("Symbol", root_scope)
+    def init_symbol(kernel : TModule)
+      symbol_type = TType.new("Symbol", kernel.scope)
       symbol_type.instance_scope["type"] = symbol_type
 
       NativeLib.def_instance_method(symbol_type, :to_s,  :symbol_to_s)

--- a/src/myst/interpreter/native_lib/top_level.cr
+++ b/src/myst/interpreter/native_lib/top_level.cr
@@ -1,0 +1,20 @@
+module Myst
+  class Interpreter
+    NativeLib.method :mt_exit, Value, status : TInteger? do
+      real_status =
+        if status.is_a?(TInteger)
+          status.value
+        else
+          0
+        end
+
+      exit(real_status.to_i32)
+    end
+
+
+    def init_top_level(kernel : TModule)
+      NativeLib.def_method(kernel, :exit, :mt_exit)
+      kernel
+    end
+  end
+end

--- a/src/myst/interpreter/nodes/instantiation.cr
+++ b/src/myst/interpreter/nodes/instantiation.cr
@@ -10,7 +10,7 @@ module Myst
 
       instance = TInstance.new(type)
       # Allow access to the type from the instance through `.type`.
-      instance.scope["type"] = type
+      instance.scope.assign("type", type)
 
       # If the instance has an `initialize` method, call it with the arguments
       # given to the Instantiation.

--- a/src/myst/syntax/exceptions.cr
+++ b/src/myst/syntax/exceptions.cr
@@ -2,16 +2,35 @@ require "./location"
 
 module Myst
   class BaseException < Exception
-  end
-
-  class SyntaxError < BaseException
     property location : Location
 
     def initialize(@location, @message="")
-      @message = "Syntax error at #{@location}: #{@message}"
+      # We're showing a custom message. The implementation backtrace is just
+      # noise to end users.
+      @callstack = nil
+    end
+
+    # For some reason, simply setting `@callstack` to nil kept showing the
+    # backtrace. This ensures that the returned backtrace will always be empty.
+    def backtrace?
+      [] of String
+    end
+  end
+
+  class SyntaxError < BaseException
+    def initialize(@location, @message="")
+      super(@location, "Syntax error at #{@location}: #{@message}")
     end
   end
 
   class ParseError < BaseException
+    def initialize(@location, @message="")
+      super(@location,
+        <<-MESSAGE
+        ParseError at #{@location}
+          #{@message}
+        MESSAGE
+      )
+    end
   end
 end

--- a/stdlib/spec.mt
+++ b/stdlib/spec.mt
@@ -1,0 +1,43 @@
+require "./io.mt"
+
+defmodule Spec
+  deftype AssertionFailure
+    def initialize(name : String)
+      @name = name
+    end
+
+    def name
+      @name
+    end
+
+    def to_s
+      name.to_s
+    end
+  end
+
+  def it(name, &block)
+    block()
+  rescue failure : AssertionFailure
+    IO.puts("Spec `" + failure.to_s + "` failed")
+  end
+
+  def it(&block)
+    it("unnamed") { }
+  end
+
+  def it(name)
+    it(name) { }
+  end
+
+
+  def assert(assertion)
+    unless assertion
+      raise %AssertionFailure{"thing"}
+    end
+  end
+
+
+  def describe(name, &block)
+    block()
+  end
+end

--- a/stdlib/spec.mt
+++ b/stdlib/spec.mt
@@ -29,7 +29,7 @@ defmodule Spec
   end
 
   def it(&block)
-    it("unnamed") { }
+    it("unnamed") { block() }
   end
 
   def it(name)

--- a/stdlib/spec.mt
+++ b/stdlib/spec.mt
@@ -1,24 +1,31 @@
-require "./io.mt"
+require "./spec/errors.mt"
+require "./spec/single_spec.mt"
 
+# Spec
+#
+# A simple library for writing specs around Myst code. Specs are written using
+# `it`, providing either a name, a code block to test, or both. Multiple `it`s
+# can be organized under a `describe` block for better visual clarity.
+#
+# The Spec library operates primarily through `assert`. Each spec can make
+# multiple calls to `assert`, with an argument that is expected to be truthy.
+# If the given argument is not truthy, the spec is considered failed, and the
+# suite will not pass.
+#
+# By default, a passing assertion will output a green `.` to the terminal,
+# while a failing assertion will output a red `F`. For now, execution will
+# immediately halt on the first assertion failure, and the program will exit
+# with a non-zero status code.
+#
+#
+# Note: A lot of this implementation exists as a workaround for not being able
+# to save references to functors into variables (they just get treated as
+# Calls). This should be addressed before too long, since it's a fairly common
+# use case, but a basic Spec library does not require it.
 defmodule Spec
-  deftype AssertionFailure
-    def initialize(name : String)
-      @name = name
-    end
-
-    def name
-      @name
-    end
-
-    def to_s
-      @name
-    end
-  end
-
   def it(name, &block)
-    block()
-  rescue failure : AssertionFailure
-    IO.puts("Spec `" + failure.to_s + "` failed")
+    spec = %SingleSpec{name}
+    spec.run{ block() }
   end
 
   def it(&block)
@@ -27,13 +34,6 @@ defmodule Spec
 
   def it(name)
     it(name) { }
-  end
-
-
-  def assert(assertion)
-    unless assertion
-      raise %AssertionFailure{"thing"}
-    end
   end
 
 

--- a/stdlib/spec.mt
+++ b/stdlib/spec.mt
@@ -11,7 +11,7 @@ defmodule Spec
     end
 
     def to_s
-      name.to_s
+      @name
     end
   end
 

--- a/stdlib/spec/errors.mt
+++ b/stdlib/spec/errors.mt
@@ -1,0 +1,26 @@
+require "./single_spec.mt"
+
+defmodule Spec
+  # AssertionFailure
+  #
+  # An AssertionFailure is a container object that is raised when an assertion
+  # made within an `it` block fails. The failure contains the Spec object that
+  # failed, the value that was expected, and the value that was received.
+  deftype AssertionFailure
+    def initialize(name : String, expected, got)
+      @name     = name
+      @expected = expected
+      @got      = got
+    end
+
+    def name;     @name;      end
+    def expected; @expected;  end
+    def got;      @got;       end
+
+    def to_s
+      "Assertion failed: <(@name)>.\n" +
+      "    Expected: <(@expected)>\n" +
+      "         Got: <(@got)>\n"
+    end
+  end
+end

--- a/stdlib/spec/single_spec.mt
+++ b/stdlib/spec/single_spec.mt
@@ -2,6 +2,7 @@ defmodule Spec
   deftype SingleSpec
     def initialize(name : String)
       @name = name
+      @container = nil
     end
 
     def name; @name; end
@@ -11,7 +12,7 @@ defmodule Spec
       IO.puts(".")
     rescue failure : AssertionFailure
       IO.puts(failure)
-      exit(127)
+      exit(1)
     end
 
 
@@ -19,6 +20,27 @@ defmodule Spec
       unless assertion
         raise %AssertionFailure{@name, true, assertion}
       end
+    end
+
+    # Expect the given block to raise an error matching the given value. If no
+    # error, or an error with a different value, is raised, the assertion fails.
+    def expect_raises(expected_error, &block)
+      block()
+      raise %AssertionFailure{@name, expected_error, "no error"}
+    rescue <expected_error>
+      # If the raised error matches what was expected, the assertion passes.
+    rescue received_error
+      # For any other error
+      raise %AssertionFailure{@name, expected_error, received_error}
+    end
+
+    # Same as `expect_raises(expected, &block)`, but without the expectation of
+    # a specific error.
+    def expect_raises(&block)
+      block()
+      raise %AssertionFailure{@name, expected_error, "no error"}
+    rescue
+      # If an error was raised, the assertion passes.
     end
   end
 end

--- a/stdlib/spec/single_spec.mt
+++ b/stdlib/spec/single_spec.mt
@@ -1,0 +1,24 @@
+defmodule Spec
+  deftype SingleSpec
+    def initialize(name : String)
+      @name = name
+    end
+
+    def name; @name; end
+
+    def run(&block)
+      block()
+      IO.puts(".")
+    rescue failure : AssertionFailure
+      IO.puts(failure)
+      exit(127)
+    end
+
+
+    def assert(assertion)
+      unless assertion
+        raise %AssertionFailure{@name, true, assertion}
+      end
+    end
+  end
+end


### PR DESCRIPTION
The `Spec` library meets the basic criteria laid out in #31:

- define a test with a name.
- make assertions on the truthiness of an expression.
- output assertion failures as failed specs, including the name of the failing test.
- return a non-zero exit status when a test fails.

There is currently no automatic way to run all specs for a project. Instead, a custom runner file needs to be written that will require all of the subsequent test files. The one for this project is at `spec/myst/spec.mt`.

With this PR, travis will also start running the in-language specs after the interpreter specs have all passed. Currently, this is just a basic set of `Integer#+` specs, but it's a starting point nonetheless. To support this, a very basic Makefile defining `spec` target has been added, which calls `crystal spec`, then calls `crystal run src/myst.cr -- spec/myst/spec.mt`, which will run the Spec suite with the custom runner as described above without generating any unnecessary binaries.