### PR TITLE
Closes #42. Implement anonymous functions

### DIFF
--- a/spec/interpreter/nodes/anonymous_function_spec.cr
+++ b/spec/interpreter/nodes/anonymous_function_spec.cr
@@ -1,0 +1,66 @@
+require "../../spec_helper.cr"
+require "../../support/nodes.cr"
+require "../../support/interpret.cr"
+
+describe "Interpreter - AnonymousFunction" do
+  it "places a Functor object on the stack" do
+    itr = parse_and_interpret %q(
+      fn
+        ->(a) { a + 1 }
+      end
+    )
+
+    functor = itr.stack.pop.as(TFunctor)
+    functor.clauses.size.should eq(1)
+  end
+
+  it "acts like a closure" do
+    itr = parse_and_interpret %q(
+      fn
+        ->(a) { a + 1 }
+      end
+    )
+
+    functor = itr.stack.pop.as(TFunctor)
+    functor.closure?.should eq(true)
+  end
+
+  it "allows clauses of various arities" do
+    itr = parse_and_interpret %q(
+      fn
+        ->(a) { a * 2 }
+        ->(a, b) { a + b }
+        ->(a, b, c) { a + b - c }
+      end
+    )
+
+    functor = itr.stack.pop.as(TFunctor)
+    functor.clauses.size.should eq(3)
+    functor.clauses.first.as(TFunctorDef).params.size.should eq(1)
+    functor.clauses.last .as(TFunctorDef).params.size.should eq(3)
+  end
+
+
+  it "does not create an entry in the current scope" do
+    itr = Interpreter.new()
+    itr.current_scope.clear
+
+    parse_and_interpret %q(
+      fn
+        ->(a) { a + 1 }
+      end
+    ), interpreter: itr
+
+    itr.current_scope.values.size.should eq(0)
+  end
+
+  it "can be assigned to a local variable" do
+    itr = parse_and_interpret %q(
+      foo = fn
+        ->(a) { a + 1 }
+      end
+    )
+
+    itr.current_scope["foo"].class.should eq(TFunctor)
+  end
+end

--- a/spec/interpreter/nodes/block_spec.cr
+++ b/spec/interpreter/nodes/block_spec.cr
@@ -6,8 +6,6 @@ describe "Interpreter - Block" do
   # Blocks are mainly identical to Defs, except they should always instantiate
   # a new functor, and the result should not be assigned in the current scope.
   it "does not assign the block into the current scope" do
-    # # TODO: revisit this spec when closures are properly implemented
-    # next
     # Ensure a clean slate for the test (no kernel, etc.)
     itr = Interpreter.new
     itr.current_scope.clear

--- a/spec/interpreter/nodes/call_spec.cr
+++ b/spec/interpreter/nodes/call_spec.cr
@@ -227,7 +227,6 @@ describe "Interpreter - Call" do
 
   # Functions have unique scopes. Assignment to a Var inside of a scope should
   # create a new entry rather than assigning to the existing entry in a parent.
-  # TODO: revisit this spec when closures are properly implemented
   it_interprets_with_assignments %q(
     a = 1
     def foo; a = 2; end

--- a/spec/syntax/lexer_spec.cr
+++ b/spec/syntax/lexer_spec.cr
@@ -40,6 +40,7 @@ STATIC_TOKENS = {
   Token::Type::RBRACE       =>  "]",
   Token::Type::LCURLY       =>  "{",
   Token::Type::RCURLY       =>  "}",
+  Token::Type::STAB         =>  "->",
   Token::Type::EOF          =>  "\0",
   Token::Type::NEWLINE      =>  "\n",
   Token::Type::WHITESPACE   =>  " ",
@@ -49,6 +50,7 @@ STATIC_TOKENS = {
   Token::Type::DEFTYPE      =>  "deftype",
   Token::Type::DEFSTATIC    =>  "defstatic",
   Token::Type::DEF          =>  "def",
+  Token::Type::FN           =>  "fn",
   Token::Type::DO           =>  "do",
   Token::Type::UNLESS       =>  "unless",
   Token::Type::ELSE         =>  "else",
@@ -159,6 +161,6 @@ describe "Lexer" do
 
   it "lexes magic constants"do
     assert_token_type %q(__FILE__),             Token::Type::MAGIC_CONST
-    assert_token_type %q(__LINE__),             Token::Type::MAGIC_CONST  
+    assert_token_type %q(__LINE__),             Token::Type::MAGIC_CONST
   end
 end

--- a/src/myst/interpreter/nodes/anonymous_function.cr
+++ b/src/myst/interpreter/nodes/anonymous_function.cr
@@ -1,0 +1,30 @@
+module Myst
+  class Interpreter
+    def visit(node : AnonymousFunction)
+      # Originally copied from `visit(node : Def)`. This should probably be
+      # extracted to a more generic method for lexical scope resolution. The
+      # difference between this and `__scopeof` is that this resolves to
+      # `instance_scope` when `current_self` is a `TType`, which is the case
+      # when defining methods on a type.
+      scope =
+        case type = current_self
+        when TType
+          type.instance_scope
+        else
+          current_scope
+        end
+
+      functor = TFunctor.new([] of Callable, scope, closure: true)
+
+      node.clauses.each do |clause|
+        functor.add_clause(TFunctorDef.new(clause))
+      end
+
+      # The functor object is never added to the current scope. The purpose
+      # of an anonymous function is exactly that, to be unnamed. Instead, the
+      # value is simply pushed onto the stack. Users can then capture these
+      # functors into variables via `*Assign`s or other captures.
+      @stack.push(functor)
+    end
+  end
+end

--- a/src/myst/syntax/ast.cr
+++ b/src/myst/syntax/ast.cr
@@ -704,6 +704,30 @@ module Myst
     def_equals_and_hash
   end
 
+  # A shorthand function definition with multiple clauses. AnonymousFunctions
+  # are most commonly used to define complex behavior in place of a block
+  # parameter for a function. Clauses are defined using a "stab" (`->`),
+  # followed by a parenthesized parameter list, then a clause body wrapped like
+  # a normal block (either with `{...}` or `do...end`).
+  #
+  # An anonymous function must be given at least one clause to be valid.
+  #
+  #   'fn'
+  #     [
+  #       '->' '(' [ param [ ',' param ]* ]? ')' [ '{' | 'do' ]
+  #         body
+  #       [ '}' | 'end' ]
+  #     ]+
+  #   'end'
+  class AnonymousFunction < Node
+    property clauses : Array(Block)
+
+    def initialize(@clauses = [] of Block)
+    end
+
+    def_equals_and_hash clauses
+  end
+
   # A module definition. The name of the module must be a Constant (i.e., it
   # must start with a capital letter).
   #

--- a/src/myst/syntax/ast.cr
+++ b/src/myst/syntax/ast.cr
@@ -216,6 +216,14 @@ module Myst
     def_equals_and_hash entries
   end
 
+  # A constant defined by the interpreter. MagicConsts are often used for
+  # meta-programming or tooling for libraries to better support end users. All
+  # MagicConsts are written in SCREAMING_CASE, and are surrounded by double
+  # underscores (`__`).
+  #
+  #   __FILE__
+  # |
+  #   __LINE__
   class MagicConst < Node
     property type : Symbol
 
@@ -224,7 +232,7 @@ module Myst
       when "__FILE__"
         new(:file)
       else "__LINE__"
-        new(:line)        
+        new(:line)
       end
     end
 
@@ -239,7 +247,7 @@ module Myst
       location.try(&.file) || ""
     end
 
-    def_equals_and_hash type    
+    def_equals_and_hash type
   end
 
   # Any node that can appear as-is on the left-hand side of an assignment. This

--- a/src/myst/syntax/lexer.cr
+++ b/src/myst/syntax/lexer.cr
@@ -254,8 +254,12 @@ module Myst
       when '-'
         @current_token.type = Token::Type::MINUS
         read_char
-        if current_char == '='
+        case current_char
+        when '='
           @current_token.type = Token::Type::MINUSOP
+          read_char
+        when '>'
+          @current_token.type = Token::Type::STAB
           read_char
         end
       when '*'
@@ -558,7 +562,7 @@ module Myst
       if current_char == '?' || current_char == '!'
         read_char
       end
-      
+
       if @reader.buffer_value == "__FILE__" || @reader.buffer_value == "__LINE__"
         @current_token.type = Token::Type::MAGIC_CONST
       end

--- a/src/myst/syntax/token.cr
+++ b/src/myst/syntax/token.cr
@@ -19,6 +19,7 @@ module Myst
       DEFTYPE       # deftype
       DEF           # def
       DEFSTATIC     # defstatic
+      FN            # fn
       DO            # do
       UNLESS        # unless
       ELSE          # else
@@ -81,6 +82,8 @@ module Myst
       LCURLY        # {
       RCURLY        # }
 
+      STAB          # ->
+
       COMMA         # ,
       POINT         # .
       COLON         # :
@@ -122,6 +125,7 @@ module Myst
           "deftype" => DEFTYPE,
           "def" => DEF,
           "defstatic" => DEFSTATIC,
+          "fn" => FN,
           "do" => DO,
           "end" => END,
           "when" => WHEN,

--- a/src/myst/syntax/token.cr
+++ b/src/myst/syntax/token.cr
@@ -106,7 +106,7 @@ module Myst
 
       def self.keywords
         [ REQUIRE, INCLUDE,
-          DEFMODULE, DEFTYPE, DEF, DEFSTATIC, DO, END,
+          DEFMODULE, DEFTYPE, DEF, DEFSTATIC, FN, DO, END,
           WHEN, UNLESS, ELSE,
           WHILE, UNTIL,
           TRUE, FALSE, NIL,


### PR DESCRIPTION
This PR introduces anonymous functions into the language. Anonymous functions are created using the `fn` keyword, followed by one or more clause definitions, and finally terminated with an `end` keyword.

Clause definitions are indicated using a "stab" (`->`). Note that this is not an _operator_ (it can't be overloaded, nor used in any situation other than clause definitions inside anonymous functions.

Clauses are constructed by the stab, a parenthesized parameter list (even if no parameters are given), and a block body using either the `{...}` or `do...end` syntax.

The main use case of anonymous functions is to define complex behavior locally, without having to leak entries into higher scopes (e.g., `current_self`). They also have the benefit of being more terse than regular method definitions, making them even more useful in scripting contexts.

More details about how this syntax was decided on can be seen in #42. More discussion on the syntax is always welcome.

Here's an example of an anonymous function being assigned to a local variable, then called a few times with various arguments:

```myst
foo = fn
  ->(1) { 2 }
  ->(2) { 4 }
  ->(3) { 6 }
  ->(a) { a + 2 }
end

IO.puts(self.foo(1)) #=> 2
IO.puts(self.foo(2)) #=> 4
IO.puts(self.foo(3)) #=> 6
IO.puts(self.foo(4)) #=> 6
IO.puts(self.foo(5)) #=> 7
```