### PR TITLE
Closes #49. Implement function capturing with `&`.

### DIFF
--- a/spec/interpreter/nodes/function_capture_spec.cr
+++ b/spec/interpreter/nodes/function_capture_spec.cr
@@ -1,0 +1,110 @@
+require "../../spec_helper.cr"
+require "../../support/nodes.cr"
+require "../../support/interpret.cr"
+
+describe "Interpreter - FunctionCapture" do
+  it "captures a function from `current_scope` into a Value" do
+    itr = parse_and_interpret %q(
+      def foo; 1 + 2; end
+
+      # Doing random work to ensure the functor is not the last Value
+      # on the stack.
+      a = 1
+      b = 2
+
+      &foo
+    )
+
+    itr.stack.pop.class.should eq(TFunctor)
+  end
+
+  it "can be assigned to a variable" do
+    itr = parse_and_interpret %q(
+      def foo; 1 + 2; end
+
+      a = 1
+
+      bar = &foo
+    )
+
+    itr.current_scope["bar"].class.should eq(TFunctor)
+  end
+
+  # This is unnecessary, since `fn` naturally returns the newly-created
+  # function anyway, but the behavior should be expectable.
+  it "can capture anonymous functions" do
+    itr = parse_and_interpret %q(
+      bar = &fn
+        ->() { 1 + 2 }
+      end
+    )
+
+    itr.stack.pop.class.should eq(TFunctor)
+  end
+
+  it "can capture a function from a local variable" do
+    itr = parse_and_interpret %q(
+      foo = &fn ->() { 1 + 2 } end
+
+      &foo
+    )
+
+    itr.stack.pop.class.should eq(TFunctor)
+  end
+
+  # Capturing literal values other than functions is allowed by the parser,
+  # but is invalid semantically.
+  [
+    "nil", "true", "false", "1", "1.0",
+    "\"hello\"", ":hello", "[]", "{}"
+  ].each do |source|
+    it "does not allow capturing `#{source}`" do
+      itr = interpret_with_mocked_output %Q(&#{source})
+      itr.errput.to_s.downcase.should match(/expected a function/)
+    end
+  end
+
+  it "can capture functions from nested Calls" do
+    itr = parse_and_interpret %q(
+      defmodule Foo
+        def foo
+        end
+      end
+
+      &Foo.foo
+    )
+
+    itr.stack.last.class.should eq(TFunctor)
+  end
+
+
+  it "is treated as a block argument when given at the end of a Call" do
+    itr = parse_and_interpret %q(
+      def foo(a, b)
+        a + b
+      end
+
+      def bar(&block)
+        block(1, 2)
+      end
+
+      bar(&foo)
+    )
+
+    itr.stack.last.should eq(val(3))
+  end
+
+  it "treats anonymous function captures as block arguments when given at the end of a Call" do
+    itr = parse_and_interpret %q(
+      def foo(&block)
+        block(1, 2)
+      end
+
+      foo(&fn
+        ->(a, b) { a + b }
+      end)
+    )
+
+    itr.stack.last.should eq(val(3))
+  end
+end

--- a/spec/syntax/parser_spec.cr
+++ b/spec/syntax/parser_spec.cr
@@ -2551,4 +2551,38 @@ describe "Parser" do
       ->() { }
     end
   ),                                FunctionCapture.new(AnonymousFunction.new([Block.new]))
+
+
+  # A function capture given as the last argument to a function call will be considered
+  # the block argument for the function.
+  it_parses %q(foo(1, 2, &bar)),    Call.new(nil, "foo", [l(1), l(2)], block: FunctionCapture.new(Call.new(nil, "bar")))
+  it_parses %q(foo(&bar)),          Call.new(nil, "foo", block: FunctionCapture.new(Call.new(nil, "bar")))
+
+  # A function capture given as anything other than the last argument is invalid.
+  it_does_not_parse %q(foo(1, &bar, 2))
+
+  # Passing functions as arguments can be achieved by capturing the function in a
+  # separate expression
+  it_parses %q(
+    bar = &baz
+    foo(1, bar, 2)
+  ),                                SimpleAssign.new(v("bar"), FunctionCapture.new(Call.new(nil, "baz"))), Call.new(nil, "foo", [l(1), v("bar"), l(2)])
+
+  # The most common use case of function capturing is to define multi-clause anonymous
+  # functions as the block argument for a Call
+  it_parses %q(
+    foo(1, 2, &fn
+      ->(1) { true }
+      ->(2) { false }
+    end)
+  ),                                Call.new(nil, "foo", [l(1), l(2)], block: FunctionCapture.new(AnonymousFunction.new([Block.new([p(nil, l(1))], body: e(l(true))), Block.new([p(nil, l(2))], body: e(l(false)))])))
+
+  # If a function capture is given as a block argument, an inline block is not allowed.
+  it_does_not_parse %q(
+    foo(&bar) { }
+  ),                /captured function/
+  it_does_not_parse %q(
+    foo(&bar) do
+    end
+  ),                /captured function/
 end

--- a/spec/syntax/parser_spec.cr
+++ b/spec/syntax/parser_spec.cr
@@ -2524,4 +2524,31 @@ describe "Parser" do
       ->(a) a + 1
     end
   )
+
+
+
+  # Function capturing
+
+  # Functions can be captured using an `&` prefix.
+  it_parses %q(&foo),               FunctionCapture.new(Call.new(nil, "foo"))
+  # The value of a capture can be any primary expression
+  it_parses %q(&self.foo),          FunctionCapture.new(Call.new(Self.new, "foo"))
+  it_parses %q(&(a || b)),          FunctionCapture.new(Or.new(Call.new(nil, "a"), Call.new(nil, "b")))
+  it_parses %q(&callbacks[:start]), FunctionCapture.new(Call.new(Call.new(nil, "callbacks"), "[]", [l(:start)]))
+  it_parses %q(&a.b.c),             FunctionCapture.new(Call.new(Call.new(Call.new(nil, "a"), "b"), "c"))
+
+  # Spacing between the ampersand and the expression is allowed, but not newlines.
+  it_parses %q(& foo),              FunctionCapture.new(Call.new(nil, "foo"))
+  it_does_not_parse %q(
+    &
+    foo
+  )
+
+  # An anonymous function can be the value of a function capture. Other literals
+  # are parseable in captures, but will fail in the interpreter.
+  it_parses %q(
+    &fn
+      ->() { }
+    end
+  ),                                FunctionCapture.new(AnonymousFunction.new([Block.new]))
 end

--- a/src/myst/interpreter/nodes/call.cr
+++ b/src/myst/interpreter/nodes/call.cr
@@ -1,6 +1,19 @@
 module Myst
   class Interpreter
     def visit(node : Call)
+      receiver, func = lookup_call(node)
+
+      @callstack.push(node)
+      if func
+        visit_call(node, receiver, func)
+      else
+        raise_not_found(node.name, receiver)
+      end
+      @callstack.pop
+    end
+
+
+    private def lookup_call(node : Call) : Tuple(Value, Value?)
       # If the Call has a receiver, lookup the Call on that receiver, otherwise
       # search the current scope.
       receiver =
@@ -19,14 +32,9 @@ module Myst
         end
       end
 
-      @callstack.push(node)
-      if func
-        visit_call(node, receiver, func)
-      else
-        raise_not_found(node.name, receiver)
-      end
-      @callstack.pop
+      {receiver, func}
     end
+
 
     private def visit_call(node, receiver, func : TFunctor)
       args = node.args.map{ |a| a.accept(self); stack.pop }

--- a/src/myst/interpreter/nodes/function_capture.cr
+++ b/src/myst/interpreter/nodes/function_capture.cr
@@ -1,0 +1,22 @@
+module Myst
+  class Interpreter
+    def visit(node : FunctionCapture)
+      value =
+        case value_node = node.value
+        when Call
+          _, func = lookup_call(value_node)
+          func
+        else
+          visit(value_node)
+          @stack.pop
+        end
+
+      # Only Function values can be captured. Any other value is an error.
+      unless value.is_a?(TFunctor)
+        raise RuntimeError.new(TString.new("Expected a function to capture"), callstack)
+      end
+
+      @stack.push(value)
+    end
+  end
+end

--- a/src/myst/syntax/ast.cr
+++ b/src/myst/syntax/ast.cr
@@ -609,7 +609,7 @@ module Myst
     property! receiver    : Node?
     property  name        : String
     property  args        : Array(Node)
-    property! block       : Block?
+    property! block       : (Block | FunctionCapture)?
     property? infix       : Bool
 
     def initialize(@receiver, @name, @args = [] of Node, @block=nil, @infix=false)

--- a/src/myst/syntax/ast.cr
+++ b/src/myst/syntax/ast.cr
@@ -250,6 +250,15 @@ module Myst
     def_equals_and_hash type
   end
 
+  class FunctionCapture < Node
+    property value : Node
+
+    def initialize(@value : Node)
+    end
+
+    def_equals_and_hash value
+  end
+
   # Any node that can appear as-is on the left-hand side of an assignment. This
   # type is only necessary to avoid some type unioning issues with Var, Const,
   # and Underscore throughout the interpreter.

--- a/src/myst/syntax/parser.cr
+++ b/src/myst/syntax/parser.cr
@@ -129,6 +129,8 @@ module Myst
         parse_conditional
       when Token::Type::WHILE, Token::Type::UNTIL
         parse_loop
+      when Token::Type::AMPERSAND
+        parse_function_capture
       when Token::Type::MAGIC_CONST
         parse_magic_constant
       else
@@ -1076,6 +1078,15 @@ module Myst
       # value interpolations.
       expect(Token::Type::COLON)
       return key
+    end
+
+
+    def parse_function_capture
+      start = expect(Token::Type::AMPERSAND)
+      skip_space
+
+      value = parse_expression
+      return FunctionCapture.new(value).at(start.location).at_end(value)
     end
 
 


### PR DESCRIPTION
Functions can now be captured and manipulated like any other value using the `&` prefix syntax. See #49 for more details.

The main points are that any function available in the current scope can be captured with `&` and assigned to a variable. Alternatively, the function can be captured as the last argument to a Call, in which case it will become the block argument for the Call.

The latter case is most useful for creating multi-clause block arguments to pass into functions:

```myst
def foo(&block)
  block(1, 2)
end

foo(&fn
  ->(2, 1) { 4 }
  ->(a, b) { a + b }
end) #=> 3
```

Notably, if a function capture is given as an argument to a Call, it _must_ be the last argument in the Call, and a further inline block will not be allowed. If either of these conditions are not met, a ParseError will be raised. This should ensure that there is no ambiguity about what value is used as the block argument for a Call.