### PR TITLE
Coerce anon fn to calls after assigned to var

### DIFF
--- a/spec/syntax/parser_spec.cr
+++ b/spec/syntax/parser_spec.cr
@@ -527,7 +527,21 @@ describe "Parser" do
   # Assignments are not allowed to methods with modifiers
   it_does_not_parse %q(a.b? = 1)
   it_does_not_parse %q(a.b! = 1)
-
+  # Assigned Anonymous Functions called should be coerced to a Call
+  it_parses %q(
+    foo = fn 
+            ->() { } 
+          end
+    foo()
+  ), SimpleAssign.new(v("foo"), AnonymousFunction.new([Block.new])), Call.new(nil, "foo")
+  it_parses %q(
+    foo = fn 
+            ->() { } 
+          end
+    bar = foo
+    bar()
+  ), SimpleAssign.new(v("foo"), AnonymousFunction.new([Block.new])), SimpleAssign.new(v("bar"), v("foo")), Call.new(nil, "bar")
+  
   # Assignments can not be made to literal values.
   it_does_not_parse %q(2 = 4),          /cannot assign to literal value/i
   it_does_not_parse %q(2.56 = 4),       /cannot assign to literal value/i

--- a/src/myst/syntax/parser.cr
+++ b/src/myst/syntax/parser.cr
@@ -712,8 +712,9 @@ module Myst
     def parse_var_or_call(receiver=nil)
       start = expect(Token::Type::IDENT, Token::Type::CONST)
       name  = start.value
-
-      if receiver.nil?
+      
+      skip_space      
+      if receiver.nil? && current_token.type != Token::Type::LPAREN
         if name.starts_with?('_')
           return Underscore.new(name).at(start.location)
         end
@@ -724,7 +725,6 @@ module Myst
       end
 
       call = Call.new(receiver, name).at(start.location)
-      skip_space
       if accept(Token::Type::LPAREN)
         skip_space_and_newlines
 


### PR DESCRIPTION
After a couple of false starts I went with the simple implementation explained in https://github.com/myst-lang/myst/issues/48

Not sure if there are any other cases we should test