### PR TITLE
Add to_s method to Type static scope

### DIFF
--- a/spec/interpreter/nodes/raise_spec.cr
+++ b/spec/interpreter/nodes/raise_spec.cr
@@ -48,13 +48,10 @@ describe "Interpreter - Raise" do
     ),                          "some exception"
     it_raises %q(
       deftype ClassException
-        defstatic to_s
-          "class exception"
-        end
       end
 
       raise ClassException
-    ),                          "class exception"
+    ),                          "ClassException"
     it_raises %q(
       defmodule ModuleException
         def to_s

--- a/spec/interpreter/nodes/type_def_spec.cr
+++ b/spec/interpreter/nodes/type_def_spec.cr
@@ -17,7 +17,7 @@ describe "Interpreter - TypeDef" do
     end
   ) do |typ, itr|
     typ.should be_a(Myst::TType)
-    typ.scope.values.size.should eq(0)
+    typ.scope.values.size.should eq(1)
     typ.scope.parent.should eq(itr.current_scope)
   end
 

--- a/spec/myst/spec.mt
+++ b/spec/myst/spec.mt
@@ -7,6 +7,7 @@ include Spec
 require "./integer_spec.mt"
 require "./string_spec.mt"
 require "./unary_ops/not_spec.mt"
+require "./type_spec.mt"
 
 # The only way to reach this point is if all of the Specs passed. Any failures
 # will immediately exit the program, so reaching here implies success.

--- a/spec/myst/type_spec.mt
+++ b/spec/myst/type_spec.mt
@@ -1,0 +1,14 @@
+require "stdlib/spec.mt"
+
+describe("Type#to_s") do
+  it("with a literal") do
+    assert({}.type.to_s == "Map")
+  end
+
+  it("with user defined type") do
+    deftype T
+    end
+    
+    assert(T.to_s == "T")
+  end
+end

--- a/src/myst/interpreter/value.cr
+++ b/src/myst/interpreter/value.cr
@@ -77,6 +77,14 @@ module Myst
     def initialize(@name : String, parent : Scope?=nil)
       @scope = Scope.new(parent)
       @instance_scope = Scope.new(parent)
+      # TODO: revist this when base object for TType is in place
+      # Currently this prevents to_s from being overriden on Types
+      @scope["to_s"] = TFunctor.new([
+        ->ttype_to_s(Value, Array(Value), TFunctor?)] of Callable)
+    end
+
+    def ttype_to_s(_a, _b, _c)
+      TString.new(@name).as(Value)
     end
 
     def type_name


### PR DESCRIPTION
This adds `to_s`  to the static scope of all Types. 

Example:
```ruby
{}.type.to_s => Map

deftype Test
end

Test.type => Test
```