### PR TITLE
Fixes #59. Bug/restoring self

### DIFF
--- a/spec/interpreter/invocation_spec.cr
+++ b/spec/interpreter/invocation_spec.cr
@@ -69,6 +69,19 @@ MODULE_DEFS = %q(
   end
 )
 
+TYPE_DEFS = %q(
+  deftype Foo
+    defstatic foo
+      :static_foo
+    end
+
+    def foo
+      :instance_foo
+    end
+  end
+)
+
+
 private def it_invokes(prelude, call, expected)
   itr = parse_and_interpret(prelude)
   # Running the prelude will leave the last definition on the stack. For
@@ -99,4 +112,7 @@ describe "Interpreter - Invocation" do
   it_invokes MODULE_DEFS, "Foo.foo(1)",     val(:one_arg)
   it_invokes MODULE_DEFS, "Foo.foo(1, 2)",  val(:two_args)
   it_invokes MODULE_DEFS, "Foo.bar",        val(:bar)
+
+  it_invokes TYPE_DEFS, "Foo.foo",    val(:static_foo)
+  it_invokes TYPE_DEFS, "%Foo{}.foo", val(:instance_foo)
 end

--- a/spec/interpreter/nodes/break_spec.cr
+++ b/spec/interpreter/nodes/break_spec.cr
@@ -34,5 +34,24 @@ describe "Interpreter - Break" do
 
       itr.stack.pop.should eq(val(1))
     end
+
+    it "restores `self` after capturing" do
+      itr = parse_and_interpret %q(
+        deftype Foo
+          def run
+            [1, 2, 3].each{ |e| break 1 }
+            foo
+          end
+
+          def foo
+            :foo
+          end
+        end
+
+        %Foo{}.run
+      )
+
+      itr.stack.pop.should eq(val(:foo))
+    end
   end
 end

--- a/spec/interpreter/nodes/next_spec.cr
+++ b/spec/interpreter/nodes/next_spec.cr
@@ -34,5 +34,24 @@ describe "Interpreter - Next" do
 
       itr.stack.pop.should eq(val(:did_not_leave_foo))
     end
+
+    it "restores `self` after capturing" do
+      itr = parse_and_interpret %q(
+        deftype Foo
+          def run
+            [1, 2, 3].each{ |e| next 1 }
+            foo
+          end
+
+          def foo
+            :foo
+          end
+        end
+
+        %Foo{}.run
+      )
+
+      itr.stack.pop.should eq(val(:foo))
+    end
   end
 end

--- a/src/myst/interpreter.cr
+++ b/src/myst/interpreter.cr
@@ -56,7 +56,12 @@ module Myst
     end
 
     def pop_self(to_size : Int)
-      self_stack.pop(self_stack.size - to_size)
+      return unless to_size >= 0
+
+      count_to_pop = self_stack.size - to_size
+      if count_to_pop > 0
+        self_stack.pop(count_to_pop)
+      end
     end
 
 

--- a/src/myst/interpreter.cr
+++ b/src/myst/interpreter.cr
@@ -55,6 +55,10 @@ module Myst
       self_stack.pop
     end
 
+    def pop_self(to_size : Int)
+      self_stack.pop(self_stack.size - to_size)
+    end
+
 
     def visit(node : Node)
       raise "Compiler bug: #{node.class.name} nodes are not yet supported."
@@ -64,7 +68,7 @@ module Myst
     def warn(message : String, node : Node)
       @warnings += 1
       unless ENV["MYST_ENV"] == "test"
-        @errput.puts("WARNING: #{message}") 
+        @errput.puts("WARNING: #{message}")
         @errput.puts("  from `#{node.name}` at #{node.location.to_s}")
       end
     end

--- a/src/myst/interpreter/native_lib/list.cr
+++ b/src/myst/interpreter/native_lib/list.cr
@@ -32,9 +32,9 @@ module Myst
 
       NativeLib.def_instance_method(list_type, :each, :list_each)
       NativeLib.def_instance_method(list_type, :size, :list_size)
-      NativeLib.def_instance_method(list_type, :+, :list_add)
-      NativeLib.def_instance_method(list_type, :[], :list_access)
-      NativeLib.def_instance_method(list_type, :[]=, :list_access_assign)
+      NativeLib.def_instance_method(list_type, :+,    :list_add)
+      NativeLib.def_instance_method(list_type, :[],   :list_access)
+      NativeLib.def_instance_method(list_type, :[]=,  :list_access_assign)
 
       list_type
     end

--- a/src/myst/interpreter/nodes/exception_handler.cr
+++ b/src/myst/interpreter/nodes/exception_handler.cr
@@ -1,13 +1,16 @@
 module Myst
   class Interpreter
     def visit(node : ExceptionHandler)
-      stack_size_at_entry = stack.size
+      selfstack_size_at_entry = self_stack.size
 
       begin
         visit(node.body)
       rescue err : RuntimeError
         # Before rescuing, restore the stack to its state from before
         # executing the body.
+        pop_self(to_size: selfstack_size_at_entry)
+
+
         handled = false
         node.rescues.each do |resc|
           self.push_scope_override
@@ -19,6 +22,12 @@ module Myst
           else
             self.pop_scope_override
           end
+
+        end
+
+        if node.ensure?
+          visit(node.ensure)
+          stack.pop
         end
 
         raise err unless handled

--- a/src/myst/interpreter/util.cr
+++ b/src/myst/interpreter/util.cr
@@ -61,7 +61,7 @@ module Myst
 
       if value_to_s = __scopeof(value)["to_s"]?
         value_to_s = value_to_s.as(TFunctor)
-        value_str = Invocation.new(self, value_to_s, value, [] of Value, nil).invoke
+        value_str = Invocation.new(self, value_to_s, value, [] of Value, nil).invoke.as(TString).value
         error_message = "No variable or method `#{name}` for #{value_str}:#{type_name}"
       end
 


### PR DESCRIPTION
There were a number of cases where the flow of control through the interpreter bypasses the normal logic for managing the `self_stack`. Namely, this was an issue with `raise` and `break`, where the implementation uses Crystal exceptions to panic up the callstack.

The solution was to manually save the state of `self_stack` before entering an `ExceptionHandler` or `Invocation`, then manually restore it when these flow control expressions are encountered.

See #59 for a slightly more in-depth description of the issue.