### PR TITLE
Closes #51. Implement Splats

### DIFF
--- a/spec/interpreter/nodes/splat_spec.cr
+++ b/spec/interpreter/nodes/splat_spec.cr
@@ -1,0 +1,113 @@
+require "../../spec_helper.cr"
+require "../../support/nodes.cr"
+require "../../support/interpret.cr"
+
+describe "Interpreter - Splat" do
+  it "calls the unary * method on the receiver" do
+    itr = parse_and_interpret %q(
+      deftype Foo
+        def *
+          [1, 2, 3]
+        end
+      end
+
+      *%Foo{}
+    )
+
+    itr.stack.last.should eq(val([1, 2, 3]))
+  end
+
+  it "expects a List value as a result" do
+    itr = interpret_with_mocked_output %q(
+      deftype Foo
+        def *
+          :not_a_list
+        end
+      end
+
+      f = %Foo{}
+      *f
+    )
+
+    itr.errput.to_s.downcase.should match(/expected a list/)
+  end
+
+  it "can be applied to a Module" do
+    itr = parse_and_interpret %q(
+      defmodule Foo
+        def *
+          [1, 2, 3]
+        end
+      end
+
+      *Foo
+    )
+
+    itr.stack.last.should eq(val([1, 2, 3]))
+  end
+
+  it "can be applied statically on a Type" do
+    itr = parse_and_interpret %q(
+      deftype Foo
+        defstatic *
+          [1, 2, 3]
+        end
+      end
+
+      *Foo
+    )
+
+    itr.stack.last.should eq(val([1, 2, 3]))
+  end
+
+  describe "when used in a List literal" do
+    it "concatenates the result after the existing List elements" do
+      itr = parse_and_interpret %q(
+        defmodule Foo
+          def *
+            [1, 2, 3]
+          end
+        end
+
+        [*Foo, 4, 5, 6]
+      )
+
+      itr.stack.last.should eq(val([1, 2, 3, 4, 5, 6]))
+    end
+
+    it "can be used multiple times" do
+      itr = parse_and_interpret %q(
+        defmodule Foo
+          def *
+            [1, 2, 3]
+          end
+        end
+
+        [*Foo, *Foo]
+      )
+
+      itr.stack.last.should eq(val([1, 2, 3, 1, 2, 3]))
+    end
+  end
+
+
+  describe "when used as a Call argument" do
+    it "concatenates the resulting List to the Call's existing arguments" do
+      itr = parse_and_interpret %q(
+        deftype Foo
+          def *
+            [1, 2, 3]
+          end
+        end
+
+        def foo(a, b, c)
+          :matched
+        end
+
+        foo(*%Foo{})
+      )
+
+      itr.stack.last.should eq(val(:matched))
+    end
+  end
+end

--- a/spec/myst/list_spec.mt
+++ b/spec/myst/list_spec.mt
@@ -1,5 +1,11 @@
 require "stdlib/spec.mt"
 
+describe("List#* (splat)") do
+  it("should return itself") do
+    assert(*[1, 2, 3] == [1, 2, 3])
+  end
+end
+
 describe("List#size") do
   it("should return 0 when size is 0") do
     assert([].size == 0)

--- a/src/myst/interpreter/native_lib/list.cr
+++ b/src/myst/interpreter/native_lib/list.cr
@@ -14,6 +14,10 @@ module Myst
       TInteger.new(this.elements.size.to_i64)
     end
 
+    NativeLib.method :list_splat, TList do
+      this
+    end
+
     NativeLib.method :list_eq, TList, other : Value do
       return TBoolean.new(false)  unless other.is_a?(TList)
       return TBoolean.new(true)   if this == other
@@ -46,6 +50,7 @@ module Myst
       NativeLib.def_instance_method(list_type, :size, :list_size)
       NativeLib.def_instance_method(list_type, :==,   :list_eq)
       NativeLib.def_instance_method(list_type, :+,    :list_add)
+      NativeLib.def_instance_method(list_type, :*,    :list_splat)
       NativeLib.def_instance_method(list_type, :[],   :list_access)
       NativeLib.def_instance_method(list_type, :[]=,  :list_access_assign)
 

--- a/src/myst/interpreter/nodes/literals.cr
+++ b/src/myst/interpreter/nodes/literals.cr
@@ -1,9 +1,21 @@
 module Myst
   class Interpreter
     def visit(node : ListLiteral)
-      elements = node.elements.map do |elem|
+      elements = [] of Value
+
+      node.elements.each do |elem|
         elem.accept(self)
-        stack.pop
+        # A Splat in a List literal should have its result concatenated in
+        # place into the new List object. In other words, a Splat should be
+        # transparent to listing out the values directly in the literal.
+        if elem.is_a?(Splat)
+          # The result of a Splat _must_ be a list, so this assertion should
+          # never fail.
+          splat_result = stack.pop.as(TList)
+          elements.concat(splat_result.elements)
+        else
+          elements << stack.pop
+        end
       end
 
       stack.push(TList.new(elements))

--- a/src/myst/interpreter/nodes/unary_ops.cr
+++ b/src/myst/interpreter/nodes/unary_ops.cr
@@ -1,6 +1,5 @@
 module Myst
   class Interpreter
-
     def visit(node : Negation)
       visit(node.value)
       value = stack.pop()
@@ -24,5 +23,23 @@ module Myst
       stack.push(result)
     end
 
+    def visit(node : Splat)
+      visit(node.value)
+      value = stack.pop
+
+      if splat_method = recursive_lookup(value, "*").as?(TFunctor)
+        splat_method = splat_method.as(TFunctor)
+        result = Invocation.new(self, splat_method, value, [] of Value, nil).invoke
+      else
+        raise_not_found("* (splat)", value)
+      end
+
+      # The result of a Splat operation is always expected to be a List
+      unless result.is_a?(TList)
+        raise RuntimeError.new(TString.new("Expected a List value from splat"), callstack)
+      end
+
+      stack.push(result)
+    end
   end
 end

--- a/src/myst/interpreter/util.cr
+++ b/src/myst/interpreter/util.cr
@@ -55,6 +55,23 @@ module Myst
       end
     end
 
+    # Attempt to lookup the given name recursively through the ancestry of the
+    # given receiver. This is mainly used for method lookup, where the simple
+    # `lookup` method does not search deep enough for a value.
+    #
+    # The method will return `nil` if no matching entry is found.
+    def recursive_lookup(receiver, name)
+      func    = current_scope[name] if current_scope.has_key?(name)
+      func  ||= __scopeof(receiver)[name]?
+      func  ||= __typeof(receiver).ancestors.each do |anc|
+        if found = __scopeof(anc)[name]?
+          break found
+        end
+      end
+
+      func
+    end
+
     def raise_not_found(name, value)
       type_name = __typeof(value).name
       error_message = "No variable or method `#{name}` for #{type_name}"


### PR DESCRIPTION
Simple Splats are now supported for use as Call arguments, List literal elements, and for general use. They are implemented using a unary `*` method definition on the receiving object.

Splats currently enforce that the result of calling the unary `*` method will be a List value. I'm not sure if this is entirely desirable, but it can be changed in the future if it is not. #51 may be a place to continue discussion on this.

Additionally, an implementation of the splat operation for Lists has been added to support the most common usecase:

```myst
def foo(a, b, c)
  a + b + c
end

foo(*[1, 2, 3]) #=> 6
```