### PR TITLE
Fix list access and list access assign

### DIFF
--- a/spec/interpreter/native_lib/list_methods_spec.cr
+++ b/spec/interpreter/native_lib/list_methods_spec.cr
@@ -18,4 +18,40 @@ describe "NativeLib - List Methods" do
       end
     ),                    [val([1, "hi", 5.4])]
   end
+
+  describe "#[]" do
+    it_interprets %q(
+      l = [1, 2, 3]
+      l[1]
+    ), [val(2)]
+
+    it_interprets %q(
+      l = []
+      l[5]
+    ), [val(nil)]
+  end
+
+  describe "#[]=" do 
+    it_interprets %q(
+      l = []
+      l[0] = 1
+    ), [val(1)]
+
+    it_interprets %q(
+      l = []
+      l[3] = 1
+      l
+    ), [val([nil, nil, nil, 1])]
+
+    it_interprets %q(
+      l = [1, 2, 3]
+      l[2] = 4
+    ), [val(4)]
+
+    it_interprets %q(
+      l = [1, 2, 3]
+      l[2] = 4
+      l
+    ), [val([1, 2, 4])]
+  end
 end

--- a/src/myst/interpreter/native_lib/list.cr
+++ b/src/myst/interpreter/native_lib/list.cr
@@ -35,10 +35,15 @@ module Myst
     end
 
     NativeLib.method :list_access, TList, index : TInteger do
-      this.elements[index.value]
+      if element = this.elements[index.value]?
+        element
+      else
+        TNil.new
+      end
     end
 
     NativeLib.method :list_access_assign, TList, index : TInteger, value : Value do
+      this.ensure_capacity(index.value + 1)
       this.elements[index.value] = value
     end
 

--- a/src/myst/interpreter/value.cr
+++ b/src/myst/interpreter/value.cr
@@ -227,6 +227,11 @@ module Myst
     def initialize(@elements=[] of Value)
     end
 
+    def ensure_capacity(size : Int)
+      count_to_add = size - self.elements.size
+      count_to_add.times { self.elements.push(TNil.new) }
+    end
+
     def type_name
       "List"
     end


### PR DESCRIPTION
Currently trying to access or assign non existent elements in the list will raise Crystal errors.  This PR fixes these and adds some specs around those NativeLib methods.

Summary of Changes:
- Check for elements at a given index, return TNil if the index is out of range
- Ensure arrays have appropriate capacity when assigning to an index