### PR TITLE
Implement List#-, List#<, List#<=

### DIFF
--- a/spec/myst/list_spec.mt
+++ b/spec/myst/list_spec.mt
@@ -42,14 +42,54 @@ end
 
 describe("List#-") do
   it("returns elements not present in second list") do
-    assert([1, 2] - [1] == [2])
+    assert(([1, 2] - [1]) == [2])
   end
 
   it("returns the first list if there are no present elements in the second list") do
-    assert([1, 2] - [3] == [1, 2])
+    assert(([1, 2] - [3]) == [1, 2])
   end
 
   it("returns any empty list if the lists are equal") do
-    assert([1, 2] - [1, 2] == [])
+    assert(([1, 2] - [1, 2]) == [])
+  end
+end
+
+describe("List#lt") do
+  it("returns true if a list is a proper subset of the other") do
+    assert(([1, "hi"] < [1, "hi", 3]) == true)
+  end
+
+  it("returns true if a list is a proper subset of the other, unsorted") do
+    assert(([3, 1] < [1, 2, 3]) == true)
+  end
+
+  it("returns false if the lists are the same") do
+    assert(([1, 2] < [1, 2]) == false)
+  end
+
+  it("returns false if the list is not a proper subset of the other") do
+    assert(([1, 2] < [1]) == false)
+  end
+end
+
+describe("List#lte") do
+  it("returns true if a list is a subset of the other") do
+    assert(([1, "hi"] <= [1, "hi", 3]) == true)
+  end
+
+  it("returns true if a list is a subset of the other, unsorted") do
+    assert(([3, 1] < [1, 2, 3]) == true)
+  end
+
+  it("returns true if the lists contain the same elemtns") do
+    assert(([1, 2] <= [1, 2]) == true)
+  end
+
+  it("returns true if the lists contain the same elements, unsorted") do
+    assert(([3, 1, 2] <= [1, 2, 3]) == true)
+  end
+
+  it("returns false if the list is not a subset of the other") do
+    assert(([1, 2] <= [1]) == false)
   end
 end

--- a/spec/myst/list_spec.mt
+++ b/spec/myst/list_spec.mt
@@ -39,3 +39,17 @@ describe("List#==") do
     assert(([1] == [1, 2]) == false)
   end
 end
+
+describe("List#-") do
+  it("returns elements not present in second list") do
+    assert([1, 2] - [1] == [2])
+  end
+
+  it("returns the first list if there are no present elements in the second list") do
+    assert([1, 2] - [3] == [1, 2])
+  end
+
+  it("returns any empty list if the lists are equal") do
+    assert([1, 2] - [1, 2] == [])
+  end
+end

--- a/src/myst/interpreter/native_lib/list.cr
+++ b/src/myst/interpreter/native_lib/list.cr
@@ -47,6 +47,10 @@ module Myst
       this.elements[index.value] = value
     end
 
+    NativeLib.method :list_minus, TList, other : TList do
+      TList.new(this.elements - other.elements)
+    end
+
     def init_list(kernel : TModule)
       list_type = TType.new("List", kernel.scope)
       list_type.instance_scope["type"] = list_type
@@ -58,6 +62,7 @@ module Myst
       NativeLib.def_instance_method(list_type, :*,    :list_splat)
       NativeLib.def_instance_method(list_type, :[],   :list_access)
       NativeLib.def_instance_method(list_type, :[]=,  :list_access_assign)
+      NativeLib.def_instance_method(list_type, :-,    :list_minus)
 
       list_type
     end

--- a/src/myst/interpreter/native_lib/list.cr
+++ b/src/myst/interpreter/native_lib/list.cr
@@ -51,6 +51,27 @@ module Myst
       TList.new(this.elements - other.elements)
     end
 
+    NativeLib.method :list_proper_subset, TList, other : TList do
+      return TBoolean.new(false)  unless other.is_a?(TList)
+      return TBoolean.new(false)  if this == other
+      
+      if (this.elements - other.elements).empty?
+        TBoolean.new(true)
+      else
+        TBoolean.new(false)
+      end
+    end
+
+    NativeLib.method :list_subset, TList, other : TList do
+      return TBoolean.new(false)  unless other.is_a?(TList)
+      
+      if (this.elements - other.elements).empty?
+        TBoolean.new(true)
+      else
+        TBoolean.new(false)
+      end
+    end
+
     def init_list(kernel : TModule)
       list_type = TType.new("List", kernel.scope)
       list_type.instance_scope["type"] = list_type
@@ -63,6 +84,8 @@ module Myst
       NativeLib.def_instance_method(list_type, :[],   :list_access)
       NativeLib.def_instance_method(list_type, :[]=,  :list_access_assign)
       NativeLib.def_instance_method(list_type, :-,    :list_minus)
+      NativeLib.def_instance_method(list_type, :<,    :list_proper_subset)
+      NativeLib.def_instance_method(list_type, :<=,   :list_subset)
 
       list_type
     end


### PR DESCRIPTION
Related https://github.com/myst-lang/myst/issues/57

Side note: I noticed when naming the List specs `List#<` or `List#<=` it was causing the specs to hang. I haven't had a chance to look into it.