### PR TITLE
read_char after peeking if not string interp

### DIFF
--- a/spec/syntax/lexer_spec.cr
+++ b/spec/syntax/lexer_spec.cr
@@ -164,4 +164,12 @@ describe "Lexer" do
     assert_token_type %q(__FILE__),             Token::Type::MAGIC_CONST
     assert_token_type %q(__LINE__),             Token::Type::MAGIC_CONST
   end
+
+  it "lexes < in a string" do
+    assert_token_type %q("<"),      Token::Type::STRING
+  end
+
+  it "lexes <()>" do
+    assert_token_type %q("<()>"), Token::Type::INTERP_START
+  end
 end

--- a/src/myst/syntax/lexer.cr
+++ b/src/myst/syntax/lexer.cr
@@ -375,6 +375,7 @@ module Myst
           if peek_char == '('
             break
           end
+          read_char
         when '"'
           skip_char
           if pop_brace(:double_quote)


### PR DESCRIPTION
Fixes https://github.com/myst-lang/myst/issues/79

After peeking and determining < is not the beginning of a string interp we need to read_char to continuing consuming the string