### PR TITLE
[stdlib] Implement Time#- for other Time

### DIFF
--- a/spec/myst/time_spec.mt
+++ b/spec/myst/time_spec.mt
@@ -58,3 +58,24 @@ describe("Time#to_s") do
     assert(t.to_s("%H") == "03")
   end
 end
+
+describe("Time#-") do
+  it("gives the difference between two times in seconds") do
+    t1 = %Time{2017, 1, 2, 3, 4, 5}
+    t2 = %Time{2017, 1, 2, 3, 4, 6}
+
+    assert(t2 - t1 == 1.0)
+  end
+
+  it("gives the difference between two times in seconds, negative") do
+    t1 = %Time{2017, 1, 2, 3, 4, 5}
+    t2 = %Time{2017, 1, 2, 3, 4, 6}
+
+    assert(t1 - t2 == -1.0)
+  end
+
+  it("raises if a non Time type is passed") do
+    t1 = %Time{2017, 1, 2, 3, 4, 5}
+    expect_raises { t1 - nil }
+  end
+end

--- a/src/myst/interpreter/native_lib/time.cr
+++ b/src/myst/interpreter/native_lib/time.cr
@@ -15,6 +15,17 @@ module Myst
       instance
     end
 
+    NativeLib.method :time_subtract, Value, other : Value do
+      case __typeof(other).name
+      when "Time"
+        this_time = to_crystal_time(this.as(TInstance))
+        other_time = to_crystal_time(other.as(TInstance))
+        TFloat.new((this_time - other_time).total_seconds)
+      else
+        raise NativeLib.error("invalid argument for Time#-: #{__typeof(other).name}", callstack)
+      end
+    end
+
     NativeLib.method :time_to_s, TInstance, format : TString? do
       crystal_time = to_crystal_time(this)
 
@@ -29,8 +40,9 @@ module Myst
       time_type = TType.new("Time", kernel.scope)
       time_type.instance_scope["type"] = time_type
 
-      NativeLib.def_method(time_type, :now,  :static_time_now)
+      NativeLib.def_method(time_type, :now, :static_time_now)
       NativeLib.def_instance_method(time_type, :to_s,  :time_to_s)
+      NativeLib.def_instance_method(time_type, :-,     :time_subtract)
 
       time_type
     end


### PR DESCRIPTION
Implements part of Time#-, allowing difference between two Time types.
The difference is returned as a Float in seconds

Example:
```ruby
t1 = %Time{2017, 1, 2, 3, 4, 5}
t2 = %Time{2017, 1, 2, 3, 4, 6}

t2 - t1  # => 1.0
```
