### PR TITLE
Fix List equality bug

### DIFF
--- a/spec/myst/list_spec.mt
+++ b/spec/myst/list_spec.mt
@@ -38,6 +38,10 @@ describe("List#==") do
   it("returns false when the lists are different lengths") do
     assert(([1] == [1, 2]) == false)
   end
+
+  it("returns false when the lists are not equal") do
+    assert(([1, 2] == [1, "hi"]) == false)
+  end
 end
 
 describe("List#-") do

--- a/src/myst/interpreter/native_lib/list.cr
+++ b/src/myst/interpreter/native_lib/list.cr
@@ -24,7 +24,7 @@ module Myst
       return TBoolean.new(false)  if this.elements.size != other.elements.size
 
       this.elements.zip(other.elements).each do |a, b|
-        return TBoolean.new(false) unless NativeLib.call_func_by_name(self, a, "==", [b])
+        return TBoolean.new(false) unless NativeLib.call_func_by_name(self, a, "==", [b]).truthy?
       end
 
       TBoolean.new(true)


### PR DESCRIPTION
Currently comparing un-equal Lists of the same size will return true.  We need to evaluate the truthiness of the NativeLib `==` call