### PR TITLE
Add __DIR__, unique MagicConst tokens

### DIFF
--- a/spec/interpreter/nodes/magic_const_spec.cr
+++ b/spec/interpreter/nodes/magic_const_spec.cr
@@ -13,4 +13,5 @@ describe "Interpreter - MagicConstant" do
   ), [val(3)]
   
   it_interprets %q(__FILE__), [val(File.join(Dir.current,"test_source.mt"))]
+  it_interprets %q(__DIR__),  [val(File.join(Dir.current))]
 end

--- a/spec/syntax/lexer_spec.cr
+++ b/spec/syntax/lexer_spec.cr
@@ -161,8 +161,9 @@ describe "Lexer" do
   end
 
   it "lexes magic constants"do
-    assert_token_type %q(__FILE__),             Token::Type::MAGIC_CONST
-    assert_token_type %q(__LINE__),             Token::Type::MAGIC_CONST
+    assert_token_type %q(__FILE__),             Token::Type::MAGIC_FILE
+    assert_token_type %q(__LINE__),             Token::Type::MAGIC_LINE
+    assert_token_type %q(__DIR__),              Token::Type::MAGIC_DIR
   end
 
   it "lexes < in a string" do

--- a/spec/syntax/parser_spec.cr
+++ b/spec/syntax/parser_spec.cr
@@ -246,8 +246,9 @@ describe "Parser" do
     }
   ),                            l({ :something => "hello", :other => 5.4 })
 
-  it_parses %q(__FILE__),       MagicConst.new(:file)
-  it_parses %q(__LINE__),       MagicConst.new(:line)
+  it_parses %q(__FILE__),       MagicConst.new(:"__FILE__")
+  it_parses %q(__LINE__),       MagicConst.new(:"__LINE__")
+  it_parses %q(__DIR__),        MagicConst.new(:"__DIR__")
 
   # Value interpolations
 

--- a/src/myst/interpreter/nodes/magic_const.cr
+++ b/src/myst/interpreter/nodes/magic_const.cr
@@ -2,10 +2,12 @@ module Myst
   class Interpreter
     def visit(node : MagicConst)
       case node.type
-      when :file
-        stack.push(TString.new(node.file)) if node.location
-      when :line
-        stack.push(TInteger.new(node.line.to_i64)) if node.location
+      when :"__FILE__"
+        stack.push(TString.new(node.file))
+      when :"__LINE__"
+        stack.push(TInteger.new(node.line.to_i64))
+      when :"__DIR__"
+        stack.push(TString.new(node.dir))
       end
     end
   end

--- a/src/myst/syntax/ast.cr
+++ b/src/myst/syntax/ast.cr
@@ -224,17 +224,10 @@ module Myst
   #   __FILE__
   # |
   #   __LINE__
+  # |
+  #   __DIR__
   class MagicConst < Node
     property type : Symbol
-
-    def self.from(name)
-      case name
-      when "__FILE__"
-        new(:file)
-      else "__LINE__"
-        new(:line)
-      end
-    end
 
     def initialize(@type : Symbol)
     end
@@ -245,6 +238,10 @@ module Myst
 
     def file
       location.try(&.file) || ""
+    end
+
+    def dir
+      location.try(&.dirname) || ""
     end
 
     def_equals_and_hash type

--- a/src/myst/syntax/lexer.cr
+++ b/src/myst/syntax/lexer.cr
@@ -564,8 +564,13 @@ module Myst
         read_char
       end
 
-      if @reader.buffer_value == "__FILE__" || @reader.buffer_value == "__LINE__"
-        @current_token.type = Token::Type::MAGIC_CONST
+      case @reader.buffer_value
+      when "__FILE__" 
+        @current_token.type = Token::Type::MAGIC_FILE
+      when "__LINE__"
+        @current_token.type = Token::Type::MAGIC_LINE
+      when "__DIR__"
+        @current_token.type = Token::Type::MAGIC_DIR
       end
 
       @current_token.value = @reader.buffer_value

--- a/src/myst/syntax/location.cr
+++ b/src/myst/syntax/location.cr
@@ -20,6 +20,10 @@ module Myst
       location_str
     end
 
+    def dirname : String?
+      file.try { |filename| File.dirname(filename) }
+    end
+
     def to_s(io : IO)
       io << to_s
     end

--- a/src/myst/syntax/parser.cr
+++ b/src/myst/syntax/parser.cr
@@ -133,7 +133,7 @@ module Myst
         parse_loop
       when Token::Type::AMPERSAND
         parse_function_capture
-      when Token::Type::MAGIC_CONST
+      when Token::Type::MAGIC_FILE, Token::Type::MAGIC_LINE, Token::Type::MAGIC_DIR
         parse_magic_constant
       else
         parse_logical_or
@@ -1039,10 +1039,16 @@ module Myst
     end
 
     def parse_magic_constant
-      start = expect(Token::Type::MAGIC_CONST)
+      token = expect(Token::Type::MAGIC_FILE, Token::Type::MAGIC_LINE, Token::Type::MAGIC_DIR)
       skip_space
-
-      return MagicConst.from(start.value).at(start.location)
+      case token.type
+      when Token::Type::MAGIC_FILE
+        MagicConst.new(:"__FILE__").at(token.location)
+      when Token::Type::MAGIC_LINE
+        MagicConst.new(:"__LINE__").at(token.location)
+      else
+        MagicConst.new(:"__DIR__").at(token.location)
+      end
     end
 
     def parse_list_literal

--- a/src/myst/syntax/token.cr
+++ b/src/myst/syntax/token.cr
@@ -43,7 +43,9 @@ module Myst
       IDENT         # [a-z][_a-zA-Z0-9]*
       CONST         # [A-Z][a-zA-Z0-9]*
       IVAR          # @[a-z][_a-zA-Z0-9]*
-      MAGIC_CONST   # __[A-Z][_A-Z]*__
+      MAGIC_FILE    # __FILE__
+      MAGIC_LINE    # __LINE__
+      MAGIC_DIR     # __DIR__
 
       PLUS          # +
       MINUS         # -


### PR DESCRIPTION
This PR adds the `__DIR__` magic constant, which returns the directory of the current file.  In addition is uses unique tokens for each type of Magic Constant, although more verbose is more explicit.