### PR TITLE
[parser,ast] Allow function captures as block parameters for instantiation

### DIFF
--- a/spec/syntax/parser_spec.cr
+++ b/spec/syntax/parser_spec.cr
@@ -529,19 +529,19 @@ describe "Parser" do
   it_does_not_parse %q(a.b! = 1)
   # Assigned Anonymous Functions called should be coerced to a Call
   it_parses %q(
-    foo = fn 
-            ->() { } 
+    foo = fn
+            ->() { }
           end
     foo()
   ), SimpleAssign.new(v("foo"), AnonymousFunction.new([Block.new])), Call.new(nil, "foo")
   it_parses %q(
-    foo = fn 
-            ->() { } 
+    foo = fn
+            ->() { }
           end
     bar = foo
     bar()
   ), SimpleAssign.new(v("foo"), AnonymousFunction.new([Block.new])), SimpleAssign.new(v("bar"), v("foo")), Call.new(nil, "bar")
-  
+
   # Assignments can not be made to literal values.
   it_does_not_parse %q(2 = 4),          /cannot assign to literal value/i
   it_does_not_parse %q(2.56 = 4),       /cannot assign to literal value/i
@@ -1126,6 +1126,13 @@ describe "Parser" do
   it_parses %q(
     %Thing{ } { |a,b| }
   ),                      Instantiation.new(c("Thing"), block: Block.new([p("a"), p("b")]))
+  # The block parameter can also be specified as a capture
+  it_parses %q(%Thing{&block}), Instantiation.new(c("Thing"), block: FunctionCapture.new(Call.new(nil, "block")))
+  it_parses %q(%Thing{
+    &fn
+      ->(){}
+    end
+  }),                    Instantiation.new(c("Thing"), block: FunctionCapture.new(AnonymousFunction.new([Block.new])))
 
   # Also as in a Call, trailing commas and the like are invalid
   it_does_not_parse %q(%Thing{ 1, })

--- a/src/myst/syntax/ast.cr
+++ b/src/myst/syntax/ast.cr
@@ -781,7 +781,7 @@ module Myst
   class Instantiation < Node
     property  type    : Node
     property  args    : Array(Node)
-    property! block   : Block?
+    property! block   : (Block | FunctionCapture)?
 
     def initialize(@type, @args=[] of Node, @block=nil)
     end


### PR DESCRIPTION
Instantiation should support all of the syntax features of a normal call. This includes using a function capture as the block parameter when it is the last argument of the instantiation.

While working on improving the Spec library, I ran into a _semantic_ error when trying to pass through a block parameter to an instantiation. The capture was treated as a regular argument, meaning the instantiation did not match any initializers, which were expecting block arguments.

An example of this usage:

```myst
deftype Thing
  def initialize(&block)
    # Storing a block for later use...already supported
    @block = &block
  end

  defstatic create(&block)
    # Passthrough with a capture as a block...would cause "No matching clause"
    %Thing{&block}
  end
end

Thing.create{ IO.puts(:hi) }
```