### PR TITLE
Use `IO.print` to compress spec output.

### DIFF
--- a/stdlib/spec/single_spec.mt
+++ b/stdlib/spec/single_spec.mt
@@ -9,7 +9,7 @@ defmodule Spec
 
     def run(&block)
       block()
-      IO.puts(".")
+      IO.print(".")
     rescue failure
       IO.puts(failure)
       exit(1)


### PR DESCRIPTION
Each spec's dot should print on the same line as the previous one. Much cleaner than having each spec show on its own line.