### PR TITLE
[nativelib,stdlib] Add `File.write(data)`.

### DIFF
--- a/src/myst/interpreter/native_lib/file_utils.cr
+++ b/src/myst/interpreter/native_lib/file_utils.cr
@@ -6,8 +6,8 @@ module Myst
       2 => File.open("/dev/stderr", "w")
     } of Int32 => File
 
-    NativeLib.method :fs_utils_open, Value, name : TString do
-      file = File.open(name.value)
+    NativeLib.method :fs_utils_open, Value, name : TString, mode : TString do
+      file = File.open(name.value, mode.value)
       @file_pool[file.fd] = file
       TInteger.new(file.fd.to_i64)
     end
@@ -38,6 +38,13 @@ module Myst
       TString.new(String.new(data))
     end
 
+    NativeLib.method :fs_utils_write, Value, fd : TInteger, data : Value do
+      file = @file_pool[fd.value]
+      data_str = NativeLib.call_func_by_name(self, data, "to_s", [] of Value).as(TString)
+      file.write(data_str.value.to_slice)
+      TNil.new
+    end
+
 
     def init_file_utils(kernel : TModule)
       fs_utils_module = TModule.new("FSUtils", kernel.scope)
@@ -47,6 +54,7 @@ module Myst
       NativeLib.def_method(fs_utils_module, :size,      :fs_utils_size)
       NativeLib.def_method(fs_utils_module, :read,      :fs_utils_read)
       NativeLib.def_method(fs_utils_module, :read_all,  :fs_utils_read_all)
+      NativeLib.def_method(fs_utils_module, :write,     :fs_utils_write)
 
       fs_utils_module
     end

--- a/stdlib/file.mt
+++ b/stdlib/file.mt
@@ -1,6 +1,7 @@
 deftype File
-  defstatic open(name : String)
-    %File{FSUtils.open(name), name}
+  defstatic open(name : String); open(name, "r"); end
+  defstatic open(name : String, mode)
+    %File{FSUtils.open(name, mode), name}
   end
 
 
@@ -22,5 +23,9 @@ deftype File
 
   def read(length : Integer)
     FSUtils.read(@fd, length)
+  end
+
+  def write(data)
+    FSUtils.write(@fd, data)
   end
 end


### PR DESCRIPTION
`File.write` is similar to `IO.print`, but writing to a file instead of to the terminal.

`File.write` relies on `FSUtils.write`, which does the actual writing. Writing a file depends on the file being opened in a writable mode. To accomodate this while maintaining read-only mode as well, `FSUtils.open` now expects a `mode` argument, and `File.open` now accepts an optional `mode` argument that will default to `"r"` for read-only. Using `"w"` or `"a"` will open the file in read mode.

This _should_ have specs around it, but I'd like `File.delete` to exist before writing them, to avoid cluttering up the file system.