### PR TITLE
Fixes #95. Pop erroneous scope overrides after rescuing errors.

### DIFF
--- a/spec/interpreter/nodes/exception_handler_spec.cr
+++ b/spec/interpreter/nodes/exception_handler_spec.cr
@@ -146,6 +146,36 @@ describe "Interpreter - ExceptionHandler" do
       itr.errput.to_s.should eq("")
       itr.output.to_s.should eq("saved\n")
     end
+
+    it "restores scope overrides after rescuing (see #95)" do
+      itr = interpret_with_mocked_output %q(
+        def inner
+          raise "woops"
+        end
+
+        def do_run
+          inner
+        rescue "woops"
+          :rescued
+        end
+
+
+        list = []
+        [1, 2, 3].each do |num|
+          # `self` reference
+          do_run
+          # local scope reference
+          num
+          # parent scope reference
+          list
+        end
+
+        :finished
+      )
+
+      itr.errput.to_s.should eq("")
+      itr.stack.last.should eq(val(:finished))
+    end
   end
 
 

--- a/src/myst/interpreter.cr
+++ b/src/myst/interpreter.cr
@@ -42,6 +42,15 @@ module Myst
       @scope_stack.pop
     end
 
+    def pop_scope_override(to_size : Int)
+      return unless to_size >= 0
+
+      count_to_pop = @scope_stack.size - to_size
+      if count_to_pop > 0
+        @scope_stack.pop(count_to_pop)
+      end
+    end
+
 
     def current_self
       self_stack.last


### PR DESCRIPTION
Similar to how the self_stack gets restored after a `rescue`, the scope_stack now gets the same restoration.

I'll be honest, having to do this for both `self` and scope overrides, this doesn't feel like the _best_ solution. A better way of snapshotting and restoring the interpreter state seems like it would help a lot and would avoid potential duplication errors.