### PR TITLE
Closes #53. [infra] Upgrade to Crystal 0.24.1.

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,6 +1,6 @@
 name: myst
 version: 0.1.0
-crystal: 0.23.1
+crystal: 0.24.1
 license: MIT
 authors:
   - Jon Egeland <jonegeland@gmail.com>

--- a/spec/interpreter/nodes/op_assign_spec.cr
+++ b/spec/interpreter/nodes/op_assign_spec.cr
@@ -10,7 +10,7 @@ describe "Interpreter - OpAssign" do
       it "cannot assign to a literal value" do
         # This is already asserted by the parser. It is simply repeated here for
         # completeness.
-        expect_raises{ parse_and_interpret %Q(false #{op} 1) }
+        expect_raises(ParseError){ parse_and_interpret %Q(false #{op} 1) }
       end
 
 
@@ -20,7 +20,7 @@ describe "Interpreter - OpAssign" do
       end
 
       it "does not allow re-assignment to constants" do
-        error = expect_raises do
+        error = expect_raises(Exception) do
           parse_and_interpret %Q(
             THING = 1
             THING #{op} 2

--- a/spec/interpreter/nodes/require_spec.cr
+++ b/spec/interpreter/nodes/require_spec.cr
@@ -65,7 +65,7 @@ Dir.cd(__DIR__) do
     end
 
     it "must be given a String value as a path" do
-      expect_raises do
+      expect_raises(Exception) do
         itr = parse_and_interpret %q(
           require true
         )

--- a/spec/interpreter/nodes/simple_assign_spec.cr
+++ b/spec/interpreter/nodes/simple_assign_spec.cr
@@ -6,7 +6,7 @@ describe "Interpreter - SimpleAssign" do
   it "cannot assign to a literal value" do
     # This is already asserted by the parser. It is simply repeated here for
     # completeness.
-    expect_raises{ parse_and_interpret %q(false = 1) }
+    expect_raises(ParseError){ parse_and_interpret %q(false = 1) }
   end
 
   # Assignments should leave the assigned value on the stack
@@ -27,7 +27,7 @@ describe "Interpreter - SimpleAssign" do
   end
 
   it "does not allow re-assignment to constants" do
-    error = expect_raises do
+    error = expect_raises(Exception) do
       parse_and_interpret %q(
         THING = 1
         THING = 2

--- a/spec/interpreter/value_spec.cr
+++ b/spec/interpreter/value_spec.cr
@@ -30,11 +30,11 @@ describe "Values" do
     # interpreter to be generated. As such, Value::from_literal cannot generate
     # them automatically from a node.
     it "does not map ListLiterals" do
-      expect_raises { Myst::Value.from_literal(ListLiteral.new).should be_a(TList) }
+      expect_raises(Exception) { Myst::Value.from_literal(ListLiteral.new).should be_a(TList) }
     end
 
     it "does not map MapLiterals" do
-      expect_raises { Myst::Value.from_literal(MapLiteral.new).should be_a(TMap) }
+      expect_raises(Exception) { Myst::Value.from_literal(MapLiteral.new).should be_a(TMap) }
     end
   end
 

--- a/spec/support/interpret.cr
+++ b/spec/support/interpret.cr
@@ -52,7 +52,7 @@ def interpret_with_mocked_output(source)
 end
 
 def interpret_with_mocked_input(source, input)
-  if input 
+  if input
     io = IO::Memory.new(input)
   else
     io = IO::Memory.new
@@ -84,7 +84,7 @@ def it_does_not_interpret(node : String, message=nil, file=__FILE__, line=__LINE
   it %Q(does not interpret #{node}), file, line, end_line do
     itr = Interpreter.new
     program = parse_program(node)
-    exception = expect_raises{ itr.run(program) }
+    exception = expect_raises(Exception){ itr.run(program) }
 
     if message
       (exception.message || "").downcase.should match(message)


### PR DESCRIPTION
Crystal 0.24.1 has finally been universally released (i.e., on `brew` and `apt` now), so Myst can upgrade properly.

The biggest issue before now was building with `--release`, which now works successfully. Sadly, the main issue I was hoping would be resolved (regarding TSymbol allocation) did not get fixed.

This commit also fixes some compilation errors that are the result of 0.24.1's stdlib changes.