### PR TITLE
[parser] Fix bug when wrapping expression in parens

### DIFF
--- a/spec/syntax/parser_spec.cr
+++ b/spec/syntax/parser_spec.cr
@@ -1282,6 +1282,10 @@ describe "Parser" do
     when true
     end
   ),                                When.new(l(true))
+  it_parses %q(
+    when (true)
+    end
+  ),                                When.new(l(true))
   it_parses %q(when true; end),     When.new(l(true))
   it_parses %q(when a == 1; end),   When.new(Call.new(Call.new(nil, "a"), "==", [l(1)], infix: true))
   # Any expression can be used as a condition
@@ -1352,6 +1356,10 @@ describe "Parser" do
   # Unless is the logical inverse of When.
   it_parses %q(
     unless true
+    end
+  ),                                Unless.new(l(true))
+  it_parses %q(
+    unless (true)
     end
   ),                                Unless.new(l(true))
   it_parses %q(unless true; end),   Unless.new(l(true))

--- a/src/myst/syntax/parser.cr
+++ b/src/myst/syntax/parser.cr
@@ -687,7 +687,7 @@ module Myst
         expr = parse_expression
         skip_space_and_newlines
         expect(Token::Type::RPAREN)
-        skip_space_and_newlines
+        skip_space
         return expr
       when Token::Type::SELF
         token = current_token


### PR DESCRIPTION
Fixes #111 

The parser is consuming the delimiter (newline) which is expected at the end of a WHEN.
