### PR TITLE
[nativelib] Add List#push

### DIFF
--- a/examples/lists.mt
+++ b/examples/lists.mt
@@ -12,3 +12,5 @@ IO.puts(memory[n])
 IO.puts([1, 2, 3] == [1, 2, 3])
 
 IO.puts([1, 2, 3])
+
+IO.puts([1, 2, 3].push(4))

--- a/spec/myst/list_spec.mt
+++ b/spec/myst/list_spec.mt
@@ -97,3 +97,11 @@ describe("List#lte") do
     assert(([1, 2] <= [1]) == false)
   end
 end
+
+describe("List#push") do
+  it("add elements to the list") do
+    assert([1,2].push(3) == [1, 2, 3])
+    assert([1,2].push("hi") == [1, 2, "hi"])
+    assert([1,2].push(nil) == [1, 2, nil])
+  end
+end

--- a/src/myst/interpreter/native_lib/list.cr
+++ b/src/myst/interpreter/native_lib/list.cr
@@ -72,6 +72,11 @@ module Myst
       end
     end
 
+    NativeLib.method :list_push, TList, value : Value do
+      this.elements.push(value)
+      this
+    end
+
     def init_list(kernel : TModule)
       list_type = TType.new("List", kernel.scope)
       list_type.instance_scope["type"] = list_type
@@ -86,6 +91,7 @@ module Myst
       NativeLib.def_instance_method(list_type, :-,    :list_minus)
       NativeLib.def_instance_method(list_type, :<,    :list_proper_subset)
       NativeLib.def_instance_method(list_type, :<=,   :list_subset)
+      NativeLib.def_instance_method(list_type, :push, :list_push)
 
       list_type
     end

--- a/stdlib/enumerable.mt
+++ b/stdlib/enumerable.mt
@@ -7,7 +7,7 @@ defmodule Enumerable
   def map(&block)
     result = []
     each do |elem|
-      result = result + [block(elem)]
+      result.push(block(elem))
     end
     result
   end
@@ -100,7 +100,7 @@ defmodule Enumerable
 
     each do |e|
       when block(e)
-        result += [e]
+        result.push(e)
       end
     end
 
@@ -171,7 +171,7 @@ defmodule Enumerable
     list = []
 
     each do |e|
-      list += [e]
+      list.push(e)
     end
 
     list


### PR DESCRIPTION
This adds List#push to the NativeLib.  It also swaps out some Enumerable implementations to use `push` instead of list concatenation.