### PR TITLE
[nativelib] Allow splats in List#push, List#unshift

### DIFF
--- a/spec/myst/list_spec.mt
+++ b/spec/myst/list_spec.mt
@@ -103,6 +103,8 @@ describe("List#push") do
     assert([1,2].push(3) == [1, 2, 3])
     assert([1,2].push("hi") == [1, 2, "hi"])
     assert([1,2].push(nil) == [1, 2, nil])
+    assert([1,2].push(*[3,4]) == [1, 2, 3, 4])
+    assert([1,2].push([3,4]) == [1, 2, [3, 4]])
   end
 
   it("returns list if no value provided") do
@@ -131,6 +133,8 @@ describe("List#unshift") do
     assert([1,2].unshift(3) == [3, 1, 2])
     assert([1,2].unshift("hi") == ["hi", 1, 2])
     assert([1,2].unshift(nil) == [nil, 1, 2])
+    assert([1,2].unshift(*[3,4]) == [3, 4, 1, 2])
+    assert([1,2].unshift([3,4]) == [[3, 4], 1, 2]) 
   end
 
   it("returns nil if no value provided") do

--- a/src/myst/interpreter/native_lib/list.cr
+++ b/src/myst/interpreter/native_lib/list.cr
@@ -72,9 +72,9 @@ module Myst
       end
     end
 
-    NativeLib.method :list_push, TList, value : Value? do
-      if value
-        this.elements.push(value)
+    NativeLib.method :list_push, TList do
+      unless __args.size.zero?
+        __args.each { |arg| this.elements.push(arg) }
       end
       this
     end
@@ -87,9 +87,9 @@ module Myst
       end
     end
 
-    NativeLib.method :list_unshift, TList, value : Value? do
-      if value
-        this.elements.unshift(value)
+    NativeLib.method :list_unshift, TList do
+      unless __args.size.zero?
+        __args.reverse_each { |arg| this.elements.unshift(arg) }
       end
       this
     end


### PR DESCRIPTION
This changes the implementation of List#push and List#unshift to allow splatted args to be pushed into the List