### PR TITLE
[nativelib] Closes #113. Implement various Map and List comparison methods

### DIFF
--- a/spec/myst/list_spec.mt
+++ b/spec/myst/list_spec.mt
@@ -32,6 +32,32 @@ describe("List#==") do
   it("returns false when the lists are not equal") do
     refute([1, 2] == [1, "hi"])
   end
+
+  it("returns false when the same elements are in different orders") do
+    refute([1, 2, 3] == [1, 3, 2])
+  end
+end
+
+describe("List#!=") do
+  it("returns false when the lists are equal") do
+    refute([1, 2] != [1, 2])
+  end
+
+  it("returns false when the lists are empty") do
+    refute([] != [])
+  end
+
+  it("returns true when the lists are different lengths") do
+    assert([1] != [1, 2])
+  end
+
+  it("returns true when the lists are not equal") do
+    assert([1, 2] != [1, "hi"])
+  end
+
+  it("returns true when the same elements are in different orders") do
+    assert([1, 2, 3] != [1, 3, 2])
+  end
 end
 
 
@@ -256,7 +282,7 @@ describe("List#unshift") do
     assert([1,2].unshift("hi") == ["hi", 1, 2])
     assert([1,2].unshift(nil) == [nil, 1, 2])
     assert([1,2].unshift(*[3,4]) == [3, 4, 1, 2])
-    assert([1,2].unshift([3,4]) == [[3, 4], 1, 2]) 
+    assert([1,2].unshift([3,4]) == [[3, 4], 1, 2])
   end
 
   it("returns nil if no value provided") do

--- a/spec/myst/map_spec.mt
+++ b/spec/myst/map_spec.mt
@@ -1,17 +1,156 @@
 require "stdlib/spec.mt"
 
 
-# TODO: Uncomment once `Map#==` gets implemented (see #113)
-#describe("Map#+") do
-#  it("returns a new Map with the combined elements of both") do
-#    assert({a: 1} + {b: 2} == {a: 1, b: 2})
-#  end
-#
-#  it("does not modify the receiving Map") do
-#    map = {a: 1}
-#    map2 = map + {b: 2}
-#  end
-#end
+describe("Map#[]") do
+  it("returns the element at the given index") do
+    map = {a: 1, b: 2}
+    assert(map[:a] == 1)
+  end
+
+  it("works on map literals") do
+    assert({a: 1, b: 2}[:a] == 1)
+  end
+
+  it("works with nested maps") do
+    assert({a: {a1: 1}}[:a][:a1] == 1)
+  end
+
+  it("returns nil for a non-existent element") do
+    assert({a: 1, b: 2}[:c] == nil)
+  end
+
+  describe("with a non-symbol index") do
+    it("returns the element at the given index") do
+      map = {<1>: :one, <2>: :two}
+      assert(map[1] == :one)
+    end
+
+    it("works on map literals") do
+      assert({<1>: :one, <2>: :two}[2] == :two)
+    end
+
+    it("works with nested maps") do
+      assert({<"map">: {a: 1}}["map"][:a] == 1)
+    end
+
+    it("returns nil for a non-existent element") do
+      assert({a: 1, b: 2}[false] == nil)
+    end
+
+    it("does not treat negative indices specially") do
+      map = {
+        <-1>: -1,
+        <0>: 0
+      }
+      assert(map[-1] == -1)
+      assert(map[-2] == nil)
+    end
+  end
+end
+
+
+describe("Map#[]=") do
+  it("assigns to the element at the given index") do
+    map = {a: 1, b: 2}
+    map[:a] = 2
+
+    assert(map[:a] == 2)
+    assert(map == {a: 2, b: 2})
+  end
+
+  it("can assign new elements in the list") do
+    map = {}
+    map[:a] = 1
+    map[:b] = 2
+
+    assert(map == {a: 1, b: 2})
+  end
+
+  describe("with a non-symbol index") do
+    it("assigns to the element at the given index") do
+      map = {a: 1, b: 2}
+      map[false] = 3
+
+      assert(map[false] == 3)
+      assert(map == {a: 1, b: 2, <false>: 3})
+    end
+
+    it("can assign new elements in the list") do
+      map = {}
+      map["a"] = 1
+      map[4.5] = 2
+
+      assert(map == {<"a">: 1, <4.5>: 2})
+    end
+  end
+end
+
+
+describe("Map#==") do
+  it("returns true when the maps are equal") do
+    assert([1, 2] == [1, 2])
+  end
+
+  it("returns true when the maps are empty") do
+    assert({} == {})
+  end
+
+  it("returns false when the lists are different lengths") do
+    refute({a: 1, b: 2} == {a: 1})
+  end
+
+  it("returns false when the lists are not equal") do
+    refute({a: 1, b: 2} == {a: 1, b: "hi"})
+  end
+
+  it("does not care about the order of entries") do
+    assert({a: 1, b: 2} == {b: 2, a: 1})
+  end
+
+  it("returns false when the maps have the same keys but different values") do
+    refute({a: 1, b: 2} == {a: 2, b: 1})
+  end
+end
+
+
+describe("Map#!=") do
+  it("returns false when the maps are equal") do
+    refute([1, 2] != [1, 2])
+  end
+
+  it("returns false when the maps are empty") do
+    refute({} != {})
+  end
+
+  it("returns true when the lists are different lengths") do
+    assert({a: 1, b: 2} != {a: 1})
+  end
+
+  it("returns true when the lists are not equal") do
+    assert({a: 1, b: 2} != {a: 1, b: "hi"})
+  end
+
+  it("does not care about the order of entries") do
+    refute({a: 1, b: 2} != {b: 2, a: 1})
+  end
+
+  it("returns true when the maps have the same keys but different values") do
+    assert({a: 1, b: 2} != {a: 2, b: 1})
+  end
+end
+
+
+describe("Map#+") do
+  it("returns a new Map with the combined elements of both") do
+    assert({a: 1} + {b: 2} == {a: 1, b: 2})
+  end
+
+  it("does not modify the receiving Map") do
+    map = {a: 1}
+    map2 = map + {b: 2}
+  end
+end
+
 
 
 describe("Map#<") do

--- a/src/myst/interpreter/native_lib/list.cr
+++ b/src/myst/interpreter/native_lib/list.cr
@@ -30,6 +30,18 @@ module Myst
       TBoolean.new(true)
     end
 
+    NativeLib.method :list_not_eq, TList, other : Value do
+      return TBoolean.new(true)   unless other.is_a?(TList)
+      return TBoolean.new(false)  if this == other
+      return TBoolean.new(true)   if this.elements.size != other.elements.size
+
+      this.elements.zip(other.elements).each do |a, b|
+        return TBoolean.new(true) if NativeLib.call_func_by_name(self, a, "==", [b]).truthy?
+      end
+
+      TBoolean.new(false)
+    end
+
     NativeLib.method :list_add, TList, other : TList do
       TList.new(this.elements + other.elements)
     end
@@ -54,7 +66,7 @@ module Myst
     NativeLib.method :list_proper_subset, TList, other : TList do
       return TBoolean.new(false)  unless other.is_a?(TList)
       return TBoolean.new(false)  if this == other
-      
+
       if (this.elements - other.elements).empty?
         TBoolean.new(true)
       else
@@ -64,7 +76,7 @@ module Myst
 
     NativeLib.method :list_subset, TList, other : TList do
       return TBoolean.new(false)  unless other.is_a?(TList)
-      
+
       if (this.elements - other.elements).empty?
         TBoolean.new(true)
       else
@@ -109,6 +121,7 @@ module Myst
       NativeLib.def_instance_method(list_type, :each,    :list_each)
       NativeLib.def_instance_method(list_type, :size,    :list_size)
       NativeLib.def_instance_method(list_type, :==,      :list_eq)
+      NativeLib.def_instance_method(list_type, :!=,      :list_not_eq)
       NativeLib.def_instance_method(list_type, :+,       :list_add)
       NativeLib.def_instance_method(list_type, :*,       :list_splat)
       NativeLib.def_instance_method(list_type, :[],      :list_access)

--- a/src/myst/interpreter/native_lib/map.cr
+++ b/src/myst/interpreter/native_lib/map.cr
@@ -18,6 +18,48 @@ module Myst
       TMap.new(this.entries.merge(other.entries))
     end
 
+    NativeLib.method :map_eq, TMap, other : Value do
+      return TBoolean.new(false)  unless other.is_a?(TMap)
+      return TBoolean.new(true)   if this == other
+      return TBoolean.new(false)  if this.entries.size != other.entries.size
+
+      # At this point, `this` and `other` must have the same number of keys,
+      # meaning that if `other` contains all of the keys that `this` does, it
+      # also cannot contain any extra keys, so it's only necessary to iterate
+      # one of the two maps' keys.
+      this.entries.keys.zip(other.entries.keys).each do |a_key, b_key|
+        return TBoolean.new(false) unless NativeLib.call_func_by_name(self, a_key, "==", [b_key]).truthy?
+        return TBoolean.new(false) unless NativeLib.call_func_by_name(self, this.entries[a_key], "==", [other.entries[b_key]]).truthy?
+      end
+
+      TBoolean.new(true)
+    end
+
+    NativeLib.method :map_not_eq, TMap, other : Value do
+      return TBoolean.new(true)   unless other.is_a?(TMap)
+      return TBoolean.new(false)  if this == other
+      return TBoolean.new(true)   if this.entries.size != other.entries.size
+
+      # At this point, `this` and `other` must have the same number of keys,
+      # meaning that if `other` contains all of the keys that `this` does, it
+      # also cannot contain any extra keys, so it's only necessary to iterate
+      # one of the two maps' keys.
+      this.entries.keys.zip(other.entries.keys).each do |a_key, b_key|
+        return TBoolean.new(true) if NativeLib.call_func_by_name(self, a_key, "==", [b_key]).truthy?
+        return TBoolean.new(true) if NativeLib.call_func_by_name(self, this.entries[a_key], "==", [other.entries[b_key]]).truthy?
+      end
+
+      TBoolean.new(true)
+    end
+
+    NativeLib.method :map_access, TMap, index : Value do
+      this.entries[index]? || TNil.new
+    end
+
+    NativeLib.method :map_access_assign, TMap, index : Value, value : Value do
+      this.entries[index] = value
+    end
+
     NativeLib.method :map_proper_subset, TMap, other : TMap do
       return TBoolean.new(false)  unless other.is_a?(TMap)
       return TBoolean.new(false)  if this.entries.keys == other.entries.keys
@@ -46,6 +88,10 @@ module Myst
       NativeLib.def_instance_method(map_type, :each, :map_each)
       NativeLib.def_instance_method(map_type, :size, :map_size)
       NativeLib.def_instance_method(map_type, :+,    :map_add)
+      NativeLib.def_instance_method(map_type, :==,   :map_eq)
+      NativeLib.def_instance_method(map_type, :!=,   :map_not_eq)
+      NativeLib.def_instance_method(map_type, :[],   :map_access)
+      NativeLib.def_instance_method(map_type, :[]=,  :map_access_assign)
       NativeLib.def_instance_method(map_type, :<,    :map_proper_subset)
       NativeLib.def_instance_method(map_type, :<=,   :map_subset)
 


### PR DESCRIPTION
This includes methods for accessing Map elements (`Map#[]` and `Map#[]=`), Map equality with `Map#==` and `Map#!=`, and List inequality with `List#!=`.

_Hopefully_, this should flesh out all of the basic comparison and equality methods for Lists and Maps, and thus for all of the basic types.