### PR TITLE
[parser] Fixes #106. Catch multiple-splat errors at parse time.

### DIFF
--- a/spec/interpreter/nodes/match_assign_spec.cr
+++ b/spec/interpreter/nodes/match_assign_spec.cr
@@ -100,10 +100,6 @@ describe "Interpreter - MatchAssign" do
   # another List, rather than being flattened into a single List.
   it_interprets_with_assignments %q([1, *list]  =: [1, [2, 3]]),  { "list"  => val([[2, 3]]) }
 
-  # Multiple splats in a pattern are invalid
-  it_does_not_interpret %q([*a, *b]       =: [1, 2])
-  it_does_not_interpret %q([1, *a, 2, *b] =: [1, 2])
-
 
   # Matching a Const that refers to a TType will check the type of the value.
   it_interprets %q(List     =: [1, 2])

--- a/spec/syntax/parser_spec.cr
+++ b/spec/syntax/parser_spec.cr
@@ -225,6 +225,7 @@ describe "Parser" do
   it_parses %q([]),             ListLiteral.new
   it_parses %q([call]),         l([Call.new(nil, "call")])
   it_parses %q([1, 2, 3]),      l([1, 2, 3])
+  it_parses %q([1 , 2, 3]),     l([1, 2, 3])
   it_parses %q([  1, 3    ]),   l([1, 3])
   it_parses %q(
     [
@@ -560,10 +561,15 @@ describe "Parser" do
   it_parses %q(:hi =: "hi"),        MatchAssign.new(l(:hi), l("hi"))
   it_parses %q(true =: false),      MatchAssign.new(l(true), l(false))
   it_parses %q([1, 2] =: [1, 2]),   MatchAssign.new(l([1, 2]), l([1, 2]))
-  it_parses %q({a: 2} =: {a: 2}),   MatchAssign.new(l({:a => 2}),l({:a => 2}))
+  it_parses %q({a: 2} =: {a: 2}),   MatchAssign.new(l({:a => 2}), l({:a => 2}))
   # Splats in list literals act as Splat collectors (as in Params).
   it_parses %q([1, *_, 3] =: list), MatchAssign.new(l([1, Splat.new(u("_")), 3]), Call.new(nil, "list"))
   it_parses %q([1, *a, 3] =: list), MatchAssign.new(l([1, Splat.new(v("a")), 3]), Call.new(nil, "list"))
+  # Only one Splat is allowed in a List pattern.
+  it_does_not_parse %q([*a, *b]       =: [1, 2])
+  it_does_not_parse %q([1, *a, 2, *b] =: [1, 2])
+  # Multiple Splats can be used if they are in different List patterns.
+  it_parses %q([[*a, 2], [3, *d]] =: list), MatchAssign.new(l([[Splat.new(v("a")), 2], [3, Splat.new(v("d"))]]), Call.new(nil, "list"))
   # Vars, Consts, and Underscores can also be used on either side.
   it_parses %q(a =: 5),             MatchAssign.new(v("a"), l(5))
   it_parses %q(Thing =: 10),        MatchAssign.new(c("Thing"), l(10))

--- a/src/myst/interpreter/matcher.cr
+++ b/src/myst/interpreter/matcher.cr
@@ -90,13 +90,12 @@ module Myst
 
       past_splat = false
       pattern.elements.each do |el|
+        # Checking for more than one Splat in the parameter List is done by
+        # the parser. Because of that guarantee, this code does not need to
+        # check for multiple Splats.
         if el.is_a?(Splat)
-          if past_splat
-            __raise_runtime_error("More than one splat collector in a List pattern is not allowed.")
-          else
-            splat = el
-            past_splat = true
-          end
+          splat = el
+          past_splat = true
         elsif past_splat
           right.unshift(el)
         else


### PR DESCRIPTION
The parser is now able to assert that List patterns may only contain a single Splat. This removes a possible RuntimeError that matchers could make with the same message, letting the user fix the problem more quickly.