### PR TITLE
Closes #105. Add `-v` and `--vv` flags for version information.

### DIFF
--- a/src/myst.cr
+++ b/src/myst.cr
@@ -19,6 +19,16 @@ OptionParser.parse! do |opts|
     exit
   end
 
+  opts.on("-v", "Display the version of the Myst interpreter.") do
+    puts Myst.version
+    exit
+  end
+
+  opts.on("-vv", "Display more version information.") do
+    puts Myst.verbose_version
+    exit
+  end
+
   opts.on("--ast", "Display the parsed AST for the input file. Code will not be executed if set.") do
     show_ast = true
     dry_run = true

--- a/src/myst/version.cr
+++ b/src/myst/version.cr
@@ -1,0 +1,30 @@
+module Myst
+  VERSION_MAJOR = 0
+  VERSION_MINOR = 3
+  VERSION_PATCH = 0
+  VERSION_EXTRA = ""
+  RELEASE_DATE = "2017-12-28"
+
+  def Myst.version
+    String.build do |str|
+      str << VERSION_MAJOR
+      str << "."
+      str << VERSION_MINOR
+      str << "."
+      str << VERSION_PATCH
+      unless VERSION_EXTRA.empty?
+        str << "-"
+        str << VERSION_EXTRA
+      end
+    end
+  end
+
+  def Myst.verbose_version
+    <<-VERSION
+    Myst version #{version} (released #{RELEASE_DATE})
+    Built on:
+    - Crystal: #{Crystal::VERSION} (#{Crystal::BUILD_COMMIT} from #{Crystal::BUILD_DATE})
+    - LLVM: #{Crystal::LLVM_VERSION}
+    VERSION
+  end
+end


### PR DESCRIPTION
Giving `-v` on the CLI will just output the semver info (major.minor.patch-extra), while `-vv` will give more verbose output, include the Crystal and LLVM version information.

Here's what that looks like on the command line:

```bash
$ myst-dev -v
0.3.0
$ myst-dev -vv
Myst version 0.3.0 (released 2017-12-28)
Built on:
- Crystal: 0.24.1 ( from 2017-12-26)
- LLVM: 5.0.1
$
```

Getting platform information seems like it will be a bit more difficult. I couldn't find anything that exposes the build platform through the standard library. Trying to use `LLVM.default_target_triple` also didn't work (threw an error with a macro in `llvm.cr`). I don't think it's super important at this point, though.