### PR TITLE
[interpreter] Only check current scope if not explicit receiver

### DIFF
--- a/spec/interpreter/nodes/call_spec.cr
+++ b/spec/interpreter/nodes/call_spec.cr
@@ -240,4 +240,18 @@ describe "Interpreter - Call" do
     def foo; a; end
     foo
   ),              [val(1)]
+
+  # Naming method same as method/variable in root scope
+  # Calling method explicity on receiver should not invoke root scope method/variable
+  it_interprets %q(
+    bar = 1
+
+    deftype Foo
+      def bar
+        "bar"
+      end
+    end
+
+    %Foo{}.bar
+  ),                [val("bar")]
 end

--- a/src/myst/interpreter/nodes/call.cr
+++ b/src/myst/interpreter/nodes/call.cr
@@ -16,16 +16,15 @@ module Myst
     private def lookup_call(node : Call) : Tuple(Value, Value?)
       # If the Call has a receiver, lookup the Call on that receiver, otherwise
       # search the current scope.
-      receiver =
+      receiver, check_current =
         if node.receiver?
           node.receiver.accept(self)
-          stack.pop
+          {stack.pop, false}
         else
-          current_self
+          {current_self, true}
         end
-
-      func = recursive_lookup(receiver, node.name)
-
+      
+      func = recursive_lookup(receiver, node.name, check_current)
       {receiver, func}
     end
 

--- a/src/myst/interpreter/util.cr
+++ b/src/myst/interpreter/util.cr
@@ -60,8 +60,8 @@ module Myst
     # `lookup` method does not search deep enough for a value.
     #
     # The method will return `nil` if no matching entry is found.
-    def recursive_lookup(receiver, name)
-      func    = current_scope[name] if current_scope.has_key?(name)
+    def recursive_lookup(receiver, name, check_current = true)
+      func    = current_scope[name] if check_current && current_scope.has_key?(name)
       func  ||= __scopeof(receiver)[name]?
       if receiver.is_a?(TType)
         func ||= receiver.extended_ancestors.each do |anc|


### PR DESCRIPTION
Fixes #120 

When looking up methods this passes a flag to only check the current_scope if desired.  This will prevent the interpreter from first checking the current_scope when there is an explicit receiver.
  