### PR TITLE
Closes #100. Allow arbitrary expressions as Call names.

### DIFF
--- a/spec/interpreter/nodes/call_spec.cr
+++ b/spec/interpreter/nodes/call_spec.cr
@@ -254,4 +254,52 @@ describe "Interpreter - Call" do
 
     %Foo{}.bar
   ),                [val("bar")]
+
+
+  # Any expression can be used as the "name" of a Call.
+  it_interprets %q(
+    a = fn ->() { :called } end
+    a()
+  ),  [val(:called)]
+
+  it_interprets %q(
+    @a = fn ->() { :called } end
+    @a()
+  ),  [val(:called)]
+
+  it_interprets %q(
+    def foo
+      :called
+    end
+
+    (@func = &foo)()
+  ),  [val(:called)]
+
+  it_interprets %q(
+    def get_func
+      fn ->() { :called } end
+    end
+
+    (get_func || @default)()
+  ),  [val(:called)]
+
+  it_interprets %q(
+    def foo(last)
+      when last
+        return :called
+      else
+        return &foo
+      end
+    end
+
+    foo(false)(false)(true)
+  ),  [val(:called)]
+
+  it_interprets %q(
+    callbacks = {
+      first: fn ->() { :called } end
+    }
+
+    callbacks[:first]()
+  ),  [val(:called)]
 end

--- a/spec/syntax/parser_spec.cr
+++ b/spec/syntax/parser_spec.cr
@@ -1177,6 +1177,7 @@ describe "Parser" do
   it_parses %q(func()(1, 2)()),           Call.new(nil, Call.new(nil, Call.new(nil, "func"), [l(1), l(2)]))
   it_parses %q(callbacks[:first]()),      Call.new(nil, Call.new(Call.new(nil, "callbacks"), "[]", [l(:first)]))
   it_parses %q((fn ->() { } end)()),      Call.new(nil, AnonymousFunction.new([Block.new]))
+  it_parses %q(<get_func>()),             Call.new(nil, i(Call.new(nil, "get_func")))
 
 
 

--- a/src/myst/interpreter/nodes/references.cr
+++ b/src/myst/interpreter/nodes/references.cr
@@ -24,7 +24,7 @@ module Myst
         stack.push(value)
       else
         @callstack.push(node)
-        raise_not_found(node.name, current_self)
+        __raise_not_found(node.name, current_self)
       end
     end
 

--- a/src/myst/interpreter/nodes/unary_ops.cr
+++ b/src/myst/interpreter/nodes/unary_ops.cr
@@ -31,7 +31,7 @@ module Myst
         splat_method = splat_method.as(TFunctor)
         result = Invocation.new(self, splat_method, value, [] of Value, nil).invoke
       else
-        raise_not_found("* (splat)", value)
+        __raise_not_found("* (splat)", value)
       end
 
       # The result of a Splat operation is always expected to be a List

--- a/src/myst/interpreter/util.cr
+++ b/src/myst/interpreter/util.cr
@@ -51,7 +51,7 @@ module Myst
         value
       else
         @callstack.push(node)
-        raise_not_found(node.name, current_self)
+        __raise_not_found(node.name, current_self)
       end
     end
 
@@ -81,13 +81,12 @@ module Myst
     end
 
 
-    def raise_not_found(name, value)
+    def __raise_not_found(name, value : Value?)
       type_name = __typeof(value).name
       error_message = "No variable or method `#{name}` for #{type_name}"
 
       if value_to_s = __scopeof(value)["to_s"]?
-        value_to_s = value_to_s.as(TFunctor)
-        value_str = Invocation.new(self, value_to_s, value, [] of Value, nil).invoke.as(TString).value
+        value_str = NativeLib.call_func_by_name(self, value, "to_s", [] of Value).as(TString).value
         error_message = "No variable or method `#{name}` for #{value_str}:#{type_name}"
       end
 

--- a/src/myst/syntax/ast.cr
+++ b/src/myst/syntax/ast.cr
@@ -588,7 +588,7 @@ module Myst
   end
 
   # A method call. Calls are the building block of functionality. Any
-  # operation not expressed by a distinct node is considered a call. For
+  # operation not expressed by a distinct node is considered a Call. For
   # example, `a + b` is a call to the method `+` on `a` with `b` as an
   # argument, `obj.member` is a call to the method `member` on `obj`, etc.
   # Additionally, any identifier that is not known to be a local variable
@@ -598,13 +598,19 @@ module Myst
   # |
   #   [ receiver '.' ] name '(' [ arg [ ',' arg ]* ] ')' [ block ]
   # |
+  #   expression '(' [ arg [ ',' arg ]* ] ')' [ block ]
+  # |
   #   arg operator arg
+  #
+  # Any expression can be forced into a Call by adding parentheses as a
+  # suffix. Complex expressions will require parentheses around the expression
+  # to avoid ambiguity. This is the third form shown above.
   #
   # The last form is for infix operations, such as `a + b` shown above, where
   # `operator` would be the `+`.
   class Call < Node
     property! receiver    : Node?
-    property  name        : String
+    property  name        : String | Node
     property  args        : Array(Node)
     property! block       : (Block | FunctionCapture)?
     property? infix       : Bool


### PR DESCRIPTION
`Call` nodes can now accept any expression as the "name" of the  Call. Calls with this syntax are assumed to have no receiver (using `current_self` instead).

This idiom also needs a name attached to it so it can be referenced consistently. I've seen "dynamic referencing", but that's not entirely accurate with other usages, such as immediately calling an anonymous function or capture-with-default expression. Any suggestions are appreciated.

Still to do on this PR:
  - consider/implement allowing value interpolations as the name of a Call with a receiver. This has a few other implications around semantics where the interpolation _must_ resolve to a Symbol or String of the name of the method to call on the object. More discussion on this is necessary, and should continue in #100.

This PR also includes some other various consistency fixes with `__raise_not_found`, etc.