### PR TITLE
Closes #102. Add block parameters as local Vars.

### DIFF
--- a/spec/interpreter/nodes/block_spec.cr
+++ b/spec/interpreter/nodes/block_spec.cr
@@ -23,14 +23,27 @@ describe "Interpreter - Block" do
   it "creates a new functor for each block" do
     itr = parse_and_interpret %q(
       def foo(&block)
-        block
+        block()
       end
 
       foo{ 1 }
       foo{ 2 }
     )
 
-    itr.stack.pop.should eq(val(2))
+    itr.stack.last.should eq(val(2))
+  end
+
+  it "is added as a variable in the local scope" do
+    # Without the parentheses, this should just return the block functor.
+    itr = parse_and_interpret %q(
+      def foo(&block)
+        block
+      end
+
+      foo{ }
+    )
+
+    itr.stack.last.class.should eq(TFunctor)
   end
 
   it "creates a closure of the environment it is defined in" do
@@ -48,6 +61,6 @@ describe "Interpreter - Block" do
       x
     )
 
-    itr.stack.pop.should eq(val(6))
+    itr.stack.last.should eq(val(6))
   end
 end

--- a/spec/syntax/parser_spec.cr
+++ b/spec/syntax/parser_spec.cr
@@ -827,7 +827,9 @@ describe "Parser" do
   # References to variables defined as parameters should be considered Vars,
   # not Calls. This also applies to the block parameter.
   it_parses %q(def foo(a); a; end),             Def.new("foo", [p("a")], e(v("a")))
-  it_parses %q(def foo(&block); block; end),  Def.new("foo", block_param: p("block", block: true), body: e(Call.new(nil, "block")))
+  it_parses %q(def foo(&block); block; end),    Def.new("foo", block_param: p("block", block: true), body: e(v("block")))
+  # The block can be forced into a Call with parentheses, like any other local variable.
+  it_parses %q(def foo(&block); block(); end),  Def.new("foo", block_param: p("block", block: true), body: e(Call.new(nil, "block")))
 
   # The Vars defined within the Def should be removed after the Def finishes.
   it_parses %q(def foo(a); end; a), Def.new("foo", [p("a")]), Call.new(nil, "a")

--- a/src/myst/syntax/parser.cr
+++ b/src/myst/syntax/parser.cr
@@ -260,9 +260,7 @@ module Myst
         param.block = true
         name = expect(Token::Type::IDENT)
         param.name = name.value
-        # Named parameters should be treated as Vars (not Calls) within the Def
-        # body. However, for a call syntax that is consistent with normal calls,
-        # the block parameter is excluded from this.
+        push_local_var(name.value)
         return param.at(start.location).at_end(name.location)
       when name = accept(Token::Type::IDENT)
         param.name = name.value

--- a/stdlib/enumerable.mt
+++ b/stdlib/enumerable.mt
@@ -112,7 +112,7 @@ defmodule Enumerable
   # Returns the element with the lowest value as determined by <
   def min
     value = nil
-    
+
     each do |e|
       when value == nil || e < value
         value = e
@@ -127,7 +127,7 @@ defmodule Enumerable
   # Returns the element with the highest value as determined by >
   def max
     value = nil
-    
+
     each do |e|
       when value == nil || e > value
         value = e
@@ -179,12 +179,12 @@ defmodule Enumerable
 
   # reduce -> element
   #
-  # For every element in the enumerable, call block 
-  # with the result of the previous call and the current 
-  # element as arguments. Return a single value 
+  # For every element in the enumerable, call block
+  # with the result of the previous call and the current
+  # element as arguments. Return a single value
   def reduce(&block)
     value = nil
-    
+
     each do |e|
       when value == nil
         value = e
@@ -199,7 +199,7 @@ defmodule Enumerable
   # reduce -> element
   #
   # Same as above but an initial value is used
-  def reduce(value, &block)    
+  def reduce(value, &block)
     each do |e|
       value = block(value, e)
     end

--- a/stdlib/integer.mt
+++ b/stdlib/integer.mt
@@ -4,9 +4,9 @@ deftype Integer
   # Call block as many times as the value of this integer.
   def times(&block)
     i = 0
-    
+
     while i < self
-      block
+      block()
       i += 1
     end
 


### PR DESCRIPTION
Block parameters now get added as a local variable in the function scope, making them properly act like function captures everywhere else.

Along with the work from #123, blocks and captured functions should now be much, _much_ nicer to work with.

The only real consequence of this change is that calling a block parameter now requires parentheses, which already matches how Calls to captured functions work, so I don't see this as a burden in any real way.