### PR TITLE
Update stdlib to use 0.3.0 improvements, various style/grammar fixes.

### DIFF
--- a/stdlib/enumerable.mt
+++ b/stdlib/enumerable.mt
@@ -21,10 +21,10 @@ defmodule Enumerable
     first = true
     each do |e|
       when first
-        str = str + e.to_s
+        str += e.to_s
         first = false
       else
-        str = str + delimiter + e.to_s
+        str += "<(delimiter)><(e)>"
       end
     end
     str
@@ -54,7 +54,8 @@ defmodule Enumerable
       when block(e)
         result = true
       else
-        break result = false
+        result = false
+        break
       end
     end
     result
@@ -68,7 +69,8 @@ defmodule Enumerable
     result = nil
     each do |e|
       when block(e)
-        break result = true
+        result = true
+        break
       else
         result = false
       end
@@ -109,7 +111,7 @@ defmodule Enumerable
 
   # min -> element
   #
-  # Returns the element with the lowest value as determined by <
+  # Returns the element with the lowest value as determined by <.
   def min
     value = nil
 
@@ -124,7 +126,7 @@ defmodule Enumerable
 
   # max -> element
   #
-  # Returns the element with the highest value as determined by >
+  # Returns the element with the highest value as determined by >.
   def max
     value = nil
 
@@ -139,7 +141,7 @@ defmodule Enumerable
 
   # sort -> list
   #
-  # Returns a sorted list of all elements
+  # Returns a sorted list of all elements.
   def sort
     list = to_list
     when size < 2
@@ -166,7 +168,7 @@ defmodule Enumerable
 
   # to_list -> list
   #
-  # Returns a list containing all elements
+  # Returns a list containing all elements.
   def to_list
     list = []
 
@@ -181,7 +183,7 @@ defmodule Enumerable
   #
   # For every element in the enumerable, call block
   # with the result of the previous call and the current
-  # element as arguments. Return a single value
+  # element as arguments. Returns a single value.
   def reduce(&block)
     value = nil
 
@@ -198,7 +200,7 @@ defmodule Enumerable
 
   # reduce -> element
   #
-  # Same as above but an initial value is used
+  # Same as above but an initial value is used.
   def reduce(value, &block)
     each do |e|
       value = block(value, e)

--- a/stdlib/list.mt
+++ b/stdlib/list.mt
@@ -11,7 +11,7 @@ deftype List
 
   # empty? -> bool
   #
-  # Return `true` if the List contains 0 characters. Return `false` otherwise.
+  # Return `true` if the List contains 0 elements. Return `false` otherwise.
   def empty?
     size == 0
   end

--- a/stdlib/map.mt
+++ b/stdlib/map.mt
@@ -1,7 +1,7 @@
 deftype Map
   # empty? -> bool
   #
-  # Return `true` if the Map contains 0 characters. Return `false` otherwise.
+  # Return `true` if the Map contains 0 entries. Return `false` otherwise.
   def empty?
     size == 0
   end

--- a/stdlib/prelude.mt
+++ b/stdlib/prelude.mt
@@ -11,9 +11,9 @@
 # will use constantly.
 
 require "./enumerable.mt"
-require "./list.mt"
 require "./file.mt"
-require "./string.mt"
-require "./map.mt"
 require "./integer.mt"
+require "./list.mt"
+require "./map.mt"
+require "./string.mt"
 require "./time.mt"

--- a/stdlib/time.mt
+++ b/stdlib/time.mt
@@ -1,38 +1,33 @@
 deftype Time
   # Logic taken from Crystal::Time
   defmodule Util
-    DAYS_MONTH = [0, 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
-
+    DAYS_MONTH      = [0, 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
     DAYS_MONTH_LEAP = [0, 31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
-    
-    SECONDS_PER_MINUTE = 60
 
-    SECONDS_PER_HOUR = 60 * SECONDS_PER_MINUTE
-
-    SECONDS_PER_DAY = 24 * SECONDS_PER_HOUR
+    SECONDS_PER_MINUTE  = 60
+    SECONDS_PER_HOUR    = 60 * SECONDS_PER_MINUTE
+    SECONDS_PER_DAY     = 24 * SECONDS_PER_HOUR
 
     NANOSECONDS_PER_MILLISECOND = 1_000_000.0
+    NANOSECONDS_PER_SECOND      = 1_000_000_000.0
+    NANOSECONDS_PER_MINUTE      = NANOSECONDS_PER_SECOND * 60
 
-    NANOSECONDS_PER_SECOND = 1_000_000_000.0
+    DAYS_PER_400_YEARS  = 365 * 400 + 97
+    DAYS_PER_100_YEARS  = 365 * 100 + 24
+    DAYS_PER_4_YEARS    = 365 * 4 + 1
 
-    NANOSECONDS_PER_MINUTE = NANOSECONDS_PER_SECOND * 60
-
-    DAYS_PER_400_YEARS = 365 * 400 + 97
-
-    DAYS_PER_100_YEARS = 365 * 100 + 24
-
-    DAYS_PER_4_YEARS = 365 * 4 + 1
 
     def leap_year?(year)
       (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
     end
 
     def absolute_days(year, month, day)
-      days = when leap_year?(year)
-                DAYS_MONTH_LEAP
-              else
-                DAYS_MONTH
-              end
+      days =
+        when leap_year?(year)
+          DAYS_MONTH_LEAP
+        else
+          DAYS_MONTH
+        end
 
       temp = 0
       m = 1
@@ -40,52 +35,52 @@ deftype Time
         temp += days[m]
         m += 1
       end
-  
+
       (day - 1) + temp + (365*(year - 1)) + ((year - 1)/4) - ((year - 1)/100) + ((year - 1)/400)
     end
 
     def year_month_day_day_year(seconds)
       m = 1
-  
+
       days = DAYS_MONTH
       total_days = seconds / SECONDS_PER_DAY
-  
+
       num400 = total_days / DAYS_PER_400_YEARS
       total_days -= num400 * DAYS_PER_400_YEARS
-  
+
       num100 = total_days / DAYS_PER_100_YEARS
       when num100 == 4 # leap
         num100 = 3
       end
       total_days -= num100 * DAYS_PER_100_YEARS
-  
+
       num4 = total_days / DAYS_PER_4_YEARS
       total_days -= num4 * DAYS_PER_4_YEARS
-  
+
       num_years = total_days / 365
-  
+
       when num_years == 4 # leap
         num_years = 3
       end
-  
+
       year = num400 * 400 + num100 * 100 + num4 * 4 + num_years + 1
-  
+
       total_days -= num_years * 365
       day_year = total_days + 1
-  
+
       dec_31_leap = num100 == 3 || num4 != 24
       when num_years == 3 && dec_31_leap # 31 dec leapyear
         days = DAYS_MONTH_LEAP
       end
-  
+
       while total_days >= days[m]
         total_days -= days[m]
         m += 1
       end
-  
+
       month = m
       day = total_days + 1
-  
+
       [year, month, day, day_year]
     end
 
@@ -148,13 +143,13 @@ deftype Time
   end
 
   def validate(year, month, day, hour, minute, second, nanosecond)
-    unless 1 <= year && year <= 9999 &&
-      1 <= month && month <= 12 &&
-      1 <= day && day <= Util.days_in_month(year, month) &&
-      0 <= hour && hour <= 23 &&
-      0 <= minute && minute <= 59 &&
-      0 <= second && second <= 59 &&
-      0 <= nanosecond && nanosecond <= Util.NANOSECONDS_PER_SECOND
+    unless  1 <= year && year <= 9999 &&
+            1 <= month && month <= 12 &&
+            1 <= day && day <= Util.days_in_month(year, month) &&
+            0 <= hour && hour <= 23 &&
+            0 <= minute && minute <= 59 &&
+            0 <= second && second <= 59 &&
+            0 <= nanosecond && nanosecond <= Util.NANOSECONDS_PER_SECOND
       raise "Invalid time"
     end
   end


### PR DESCRIPTION
Some stdlib methods from a while ago were still using workarounds like `a = a + 1` from when `+=` didn't exist. This commit updates those cases to use all of the improvements from 0.3.0.

Also included in this commit are various grammar and punctuation fixes, as well as a few stylistic changes.

I'll leave this open for a while in case anyone has any other suggestions or fixes for style or grammar anywhere so that they can all be consolidated into this PR.