### PR TITLE
Closes #81. Capture `self` as part of a closure.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,5 @@
 
 # The myst executable
 /myst
-/bytecode_generator
+# DWARF file from compiling on macOS
+/myst.dwarf

--- a/spec/interpreter/invocation_spec.cr
+++ b/spec/interpreter/invocation_spec.cr
@@ -115,4 +115,28 @@ describe "Interpreter - Invocation" do
 
   it_invokes TYPE_DEFS, "Foo.foo",    val(:static_foo)
   it_invokes TYPE_DEFS, "%Foo{}.foo", val(:instance_foo)
+
+
+  it "restores the value of `self` after executing with a receiver" do
+    itr = Interpreter.new
+    original_self = itr.current_self
+
+    parse_and_interpret %q(
+      "hello, world".size
+    ), interpreter: itr
+
+    itr.current_self.should eq(original_self)
+  end
+
+  it "restores the value of `self` after executing a closure" do
+    itr = Interpreter.new
+    original_self = itr.current_self
+
+    parse_and_interpret %q(
+      @sum = 0
+      [1, 2, 3].each{ |e| @sum += e }
+    ), interpreter: itr
+
+    itr.current_self.should eq(original_self)
+  end
 end

--- a/spec/interpreter/nodes/anonymous_function_spec.cr
+++ b/spec/interpreter/nodes/anonymous_function_spec.cr
@@ -16,13 +16,32 @@ describe "Interpreter - AnonymousFunction" do
 
   it "acts like a closure" do
     itr = parse_and_interpret %q(
-      fn
-        ->(a) { a + 1 }
+      def foo
+        :called_foo
       end
+
+      func = fn
+        ->() { foo }
+      end
+
+      func()
     )
 
-    functor = itr.stack.pop.as(TFunctor)
-    functor.closure?.should eq(true)
+    itr.stack.last.should eq(val(:called_foo))
+  end
+
+  it "captures the value of `self` as part of the closure" do
+    itr = parse_and_interpret %q(
+      @sum = 0
+      func = fn
+        ->(a) { @sum += a }
+      end
+
+      func(6)
+      @sum
+    )
+
+    itr.stack.last.should eq(val(6))
   end
 
   it "allows clauses of various arities" do

--- a/spec/interpreter/nodes/block_spec.cr
+++ b/spec/interpreter/nodes/block_spec.cr
@@ -63,4 +63,14 @@ describe "Interpreter - Block" do
 
     itr.stack.last.should eq(val(6))
   end
+
+  it "captures the value of `self` as part of the closure" do
+    itr = parse_and_interpret %q(
+      @sum = 0
+      [1, 2, 3].each{ |e| @sum += e }
+      @sum
+    )
+
+    itr.stack.last.should eq(val(6))
+  end
 end

--- a/src/myst/interpreter/nodes/anonymous_function.cr
+++ b/src/myst/interpreter/nodes/anonymous_function.cr
@@ -14,7 +14,7 @@ module Myst
           current_scope
         end
 
-      functor = TFunctor.new([] of Callable, scope, closure: true)
+      functor = TFunctor.new([] of Callable, scope, closure: true, closed_self: current_self)
 
       node.clauses.each do |clause|
         functor.add_clause(TFunctorDef.new(clause))

--- a/src/myst/interpreter/nodes/def.cr
+++ b/src/myst/interpreter/nodes/def.cr
@@ -27,7 +27,7 @@ module Myst
           scope.assign(node.name, functor)
         end
       else
-        functor = TFunctor.new([] of Callable, scope, closure: true)
+        functor = TFunctor.new([] of Callable, scope, closure: true, closed_self: current_self)
       end
 
       functor.add_clause(TFunctorDef.new(node))

--- a/src/myst/interpreter/value.cr
+++ b/src/myst/interpreter/value.cr
@@ -286,8 +286,9 @@ module Myst
     property  clauses         : Array(Callable)
     property  lexical_scope   : Scope
     property? closure         : Bool
+    property!  closed_self     : Value?
 
-    def initialize(@clauses=[] of Callable, @lexical_scope : Scope=Scope.new, @closure : Bool=false)
+    def initialize(@clauses=[] of Callable, @lexical_scope : Scope=Scope.new, @closure : Bool=false, @closed_self : Value?=nil)
     end
 
     def add_clause(definition : Callable)


### PR DESCRIPTION
Closures (blocks and anonymous functions) now also "capture" the value of `self` where they are defined. This is actually done by the functor itself, rather than the `ClosureScope`, but that implementation is transparent to the rest of the interpreter.

This PR also adds a few extra specs to ensure that Invocations always restore the original value of `self` after executing.