### PR TITLE
Closes #143. Check ancestors when performing type restrictions.

### DIFF
--- a/src/myst/interpreter/matcher.cr
+++ b/src/myst/interpreter/matcher.cr
@@ -35,10 +35,15 @@ module Myst
       visit(pattern)
       left = stack.pop
       success =
-        if left.is_a?(TType) && !right.is_a?(TType)
-          # For types, check that `right` is either an instance of that type, or
-          # the type itself.
-          left == __typeof(right)
+        if left.is_a?(TType) || left.is_a?(TModule)
+          # For TType values, check extended_ancestors of the value type.
+          # For all other values, check ancestors of the value type.
+          if right.is_a?(TType)
+            right == left || right.extended_ancestors.includes?(left)
+          else
+            type_of_right = __typeof(right)
+            type_of_right == left || type_of_right.ancestors.includes?(left)
+          end
         else
           left == right
         end


### PR DESCRIPTION
This PR amends `match_value` to check the ancestors of values when performing type matching. There are three cases that can occur here:

- When the pattern is a Type or Module, and the value is a Type, check the `extended_ancestors` of the value Type. Only extended ancestors are checked, because included modules are only available to instances of a type, not the type itself.
- When the pattern is a Type or Module, and the value is _not_ a Type, check the `ancestors` of the value Type. This is the alternative to the above.
- For any other case, only check immediate equality of the value and the pattern.