### PR TITLE
Closes #144. Disallow re-using local variable names as function names

### DIFF
--- a/spec/syntax/parser_spec.cr
+++ b/spec/syntax/parser_spec.cr
@@ -766,6 +766,16 @@ describe "Parser" do
   it_parses %q(def foo_!; end), Def.new("foo_!")
   it_parses %q(def foo_?; end), Def.new("foo_?")
 
+  # Identifiers that already exist as local variables cannot be used as function names.
+  it_does_not_parse %q(foo = 1; def foo; end), /collides/
+  # Variables outside of the current scope do not count as collisions
+  it_parses %q(
+    foo = 1
+    defmodule Bar
+      def foo; end
+    end
+  )
+
   # `=` can also be appended to any non-modified identifier.
   it_parses %q(def foo=;    end), Def.new("foo=")
   it_parses %q(def foo_=(); end), Def.new("foo_=")
@@ -2639,7 +2649,7 @@ describe "Parser" do
       rescue
       end
     end
-  ),                AnonymousFunction.new([Block.new(body: ExceptionHandler.new(Nop.new, [Rescue.new]))])  
+  ),                AnonymousFunction.new([Block.new(body: ExceptionHandler.new(Nop.new, [Rescue.new]))])
   # The trailing clauses may contain any valid Expressions node.
   it_parses %q(
     fn ->() do
@@ -2650,7 +2660,7 @@ describe "Parser" do
     end
   ),                AnonymousFunction.new([Block.new(body: ExceptionHandler.new(Nop.new, [Rescue.new(e(Call.new(l(1), "+", [l(2)], infix: true), SimpleAssign.new(v("a"), l(1))))]))])
   it_parses %q(
-  fn 
+  fn
     ->() do rescue; a; end
   end
   ),                AnonymousFunction.new([Block.new(body: ExceptionHandler.new(Nop.new, [Rescue.new(e(Call.new(nil, "a")))]))])
@@ -2703,7 +2713,7 @@ describe "Parser" do
       rescue a : Integer
       end
     end
-  ),                AnonymousFunction.new([Block.new(body: ExceptionHandler.new(Nop.new, [Rescue.new(Nop.new, p("a", restriction: c("Integer")))]))])  
+  ),                AnonymousFunction.new([Block.new(body: ExceptionHandler.new(Nop.new, [Rescue.new(Nop.new, p("a", restriction: c("Integer")))]))])
   it_does_not_parse %q(
     fn ->() do
       rescue a : 123

--- a/src/myst/syntax/parser.cr
+++ b/src/myst/syntax/parser.cr
@@ -145,6 +145,10 @@ module Myst
       static = (start.type == Token::Type::DEFSTATIC)
       skip_space
       name = parse_def_name
+      if is_local_var?(name)
+        raise ParseError.new(current_location, "Function name `#{name}` collides with existing local variable. Clauses defined with `def` cannot be applied to variables.\n")
+      end
+
       method_def = Def.new(name, static: static).at(start.location)
       push_var_scope
 
@@ -680,7 +684,7 @@ module Myst
         end
 
         return parse_postfix(call)
-      
+
       # While `parse_var_or_call` can distinguish Calls for string identifiers,
       # its isolated scope (just the current token) means it cannot be
       # responsible for parsing Calls from arbitrary expressions. However,


### PR DESCRIPTION
When the Parser encounters a `Def` with a name that already exists in the current var scope, it will now raise a ParseError. This should avoid casting errors at run-time where the interpreter looks up a name expecting it to be a function but it is not.

This rule only applies to the current local scope. Entries in parent scopes do not affect this collision detection. For example:

```myst
foo = 1
def foo; end
```

will raise a `ParseError`, but

```myst
foo = 1
defmodule Bar
  def foo; end
end
```

will parse just fine, since the _variable_ `foo` is not defined in the same scope as the _function_ `foo`.

This is implemented as part of the parser to provide feedback as early as possible. While it would be possible to change the interpreter to allow `Def`s to work with local variables that happen to be functions, this is not always guaranteed, so it is simpler to disallow this behavior and tell users earlier.