### PR TITLE
Closes #142. Implement general type inheritance for TTypes.

### DIFF
--- a/.sentry.yml
+++ b/.sentry.yml
@@ -5,7 +5,8 @@
 # every time any of the source files changes.
 display_name: myst specs
 info: true
-build: crystal spec
+# `|| echo` makes sure that sentry keeps running even if there the specs fail.
+build: crystal spec --no-debug || echo ''
 run: # nothing to do
 watch:
   - ./src/myst/**/*.cr

--- a/.sentry.yml
+++ b/.sentry.yml
@@ -1,0 +1,12 @@
+# See https://github.com/samueleaton/sentry/blob/master/.sentry.example.yml
+# for more information about configuration options.
+
+# By default, this file configures sentry to run the native specs for Myst
+# every time any of the source files changes.
+display_name: myst specs
+info: true
+build: crystal spec
+run: # nothing to do
+watch:
+  - ./src/myst/**/*.cr
+  - ./spec/**/*.cr

--- a/spec/interpreter/nodes/extend_spec.cr
+++ b/spec/interpreter/nodes/extend_spec.cr
@@ -15,14 +15,14 @@ EXT_MODULE_DEF = %q(
 )
 
 TYPE_DEF = %q(
-	deftype Baz
+  deftype Baz
     extend Foo
 
-		def bar
-			"bar called"
-		end
+    def bar
+      "bar called"
+    end
 
-	end
+  end
 )
 
 describe "Interpreter - Extend" do

--- a/spec/syntax/parser_spec.cr
+++ b/spec/syntax/parser_spec.cr
@@ -1025,6 +1025,43 @@ describe "Parser" do
   ),                TypeDef.new("Thing", body: e(TypeDef.new("Part")))
 
 
+  # Inheritance
+
+  # Types can inherit from other types using a syntax similar to type restrictions
+  it_parses %q(deftype Foo : Bar; end),             TypeDef.new("Foo", supertype: c("Bar"))
+  # The supertype can be a namespaced name
+  it_parses %q(deftype Foo : Bar.Baz; end),         TypeDef.new("Foo", supertype: Call.new(c("Bar"), "Baz"))
+  it_parses %q(deftype Foo : Bar.Baz.Foo; end),     TypeDef.new("Foo", supertype: Call.new(Call.new(c("Bar"), "Baz"), "Foo"))
+  # Type supertype can also be interpolated
+  it_parses %q(deftype Foo : <get_supertype>; end), TypeDef.new("Foo", supertype: i(Call.new(nil, "get_supertype")))
+  # If a colon is given, a type name is required
+  it_does_not_parse %q(deftype Foo : ; end)
+  it_does_not_parse %q(
+    deftype Foo :
+    end
+  )
+  # The separating colon must be padded with a space to avoid confusion with a Symbol.
+  it_does_not_parse %q(
+    deftype Foo:Bar; end
+  )
+  # The supertype name must be given on the same line as the type
+  it_does_not_parse %q(
+    deftype Foo :
+      Bar
+    end
+  )
+  it_does_not_parse %q(
+    deftype Foo
+      : Bar
+    end
+  )
+  # Type paths must be given with no spaces
+  it_does_not_parse %q(deftype Foo : Bar . Baz; end)
+  # Inheritance is only valid on type definitions
+  it_does_not_parse %q(defmodule Foo : Bar; end)
+
+
+
   # Type methods
 
   it_parses %q(

--- a/src/myst/interpreter/nodes/type_def.cr
+++ b/src/myst/interpreter/nodes/type_def.cr
@@ -5,8 +5,23 @@ module Myst
       # use it. Otherwise, create a new type in the current scope.
       if current_scope.has_key?(node.name)
         type = current_scope[node.name].as(TType)
+        if node.supertype?
+          __raise_runtime_error("Specifying a supertype when re-opening an existing type is not allowed.")
+        end
       else
-        type = TType.new(node.name, current_scope)
+        supertype =
+          if node.supertype?
+            visit(node.supertype)
+            typ = stack.pop
+            unless typ.is_a?(TType)
+              __raise_runtime_error("Supertype of #{node.name} must be a Type object, but resolved to a #{typ.type_name}")
+            end
+            typ
+          else
+            nil
+          end
+
+        type = TType.new(node.name, current_scope, supertype: supertype)
         current_scope.assign(node.name, type)
       end
 

--- a/src/myst/syntax/ast.cr
+++ b/src/myst/syntax/ast.cr
@@ -784,14 +784,15 @@ module Myst
   # A type definition. TypeDefs are similar to ModuleDefs, but define a data
   # type that can be instantiated similar to how Literals create primitives.
   #
-  #   'deftype' const
+  #   'deftype' const : const
   #     body
   #   'end'
   class TypeDef < Node
-    property name       : String
-    property body       : Node
+    property  name       : String
+    property  body       : Node
+    property! supertype  : Call | Const | ValueInterpolation | Nil
 
-    def initialize(@name, @body=Nop.new)
+    def initialize(@name, @body=Nop.new, @supertype=nil)
     end
 
     def accept_children(visitor)


### PR DESCRIPTION
Type definitions can now declare a "supertype" that the type inherits behavior from. For now, only one supertype can be defined.

Similar to Ruby and related languages, supertypes are appended to the list of ancestors, meaning that any included/extended modules for a type will be checked _before_ checking the 

Inheritance is implemented in Myst using the same type restriction syntax as method parameters. For example:

```myst
deftype Foo
end

# Here, `Bar` is defined with `Foo` as a supertype.
deftype Bar : Foo
end
```

The supertype can also be defined as a path name (type nested within another type/module), or as a value interpolation that resolves to a Type object:

```myst
defmodule Foo
  deftype Bar
  end
end

deftype Baz : Foo.Bar
end

type_to_inherit_from = Baz

deftype Thing : <(type_to_inherit_from || Foo.Bar)>
end
```

If the resolved object for the supertype is _not_ a Type object, a runtime error will be raised.

See the last commit for details about the implementation changes this feature required.