### PR TITLE
Fixes #154. Add proper specs for `while` and `until`, catch `break` exceptions to stop looping.

### DIFF
--- a/spec/interpreter/nodes/until_spec.cr
+++ b/spec/interpreter/nodes/until_spec.cr
@@ -3,21 +3,55 @@ require "../../support/nodes.cr"
 require "../../support/interpret.cr"
 
 describe "Interpreter - Until" do
+  # `until` repeatedly executes its body as long as its condition is falsey.
   it_interprets %q(
     a = 1
-    until a == 1
-      a = 2
-      "ran"
+    until a >= 3
+      a += 1
     end
-  ),                  [val(nil)]
+
+    a
+  ),                  [val(3)]
+
+  # If the condition is immediately truthy, the body is never run.
+  it_interprets %q(
+    a = 1
+    until a >= 1
+      a += 1
+    end
+
+    a
+  ),                  [val(1)]
+
+  # By default, `until` returns `nil`.
   it_interprets %q(
     a = 1
     until a != 1
-      "ran"
+      a = 2
     end
   ),                  [val(nil)]
+
+  # Looping can be stopped early by using `break`.
   it_interprets %q(
-    a = 1
-    until a != 1; end
-  ),                  [val(nil)]
+    x = 0
+    until x >= 5
+      when x == 2
+        break
+      end
+      x += 1
+    end
+
+    x
+  ),                  [val(2)]
+
+  # Using `break` with a value sets the return value of the `until`.
+  it_interprets %q(
+    x = 0
+    until x >= 5
+      when x == 2
+        break x
+      end
+      x += 1
+    end
+  ),                  [val(2)]
 end

--- a/spec/interpreter/nodes/while_spec.cr
+++ b/spec/interpreter/nodes/while_spec.cr
@@ -3,21 +3,55 @@ require "../../support/nodes.cr"
 require "../../support/interpret.cr"
 
 describe "Interpreter - While" do
+  # `while` repeatedly executes its body as long as its condition is truthy.
+  it_interprets %q(
+    a = 1
+    while a < 3
+      a += 1
+    end
+
+    a
+  ),                  [val(3)]
+
+  # If the condition is immediately falsey, the body is never run.
+  it_interprets %q(
+    a = 1
+    while a < 1
+      a += 1
+    end
+
+    a
+  ),                  [val(1)]
+
+  # By default, `while` returns `nil`.
   it_interprets %q(
     a = 1
     while a == 1
       a = 2
-      "ran"
     end
   ),                  [val(nil)]
+
+  # Looping can be stopped early by using `break`.
   it_interprets %q(
-    a = 1
-    while a != 1
-      "ran"
+    x = 0
+    while x < 5
+      when x == 2
+        break
+      end
+      x += 1
     end
-  ),                  [val(nil)]
+
+    x
+  ),                  [val(2)]
+
+  # Using `break` with a value sets the return value of the `while`.
   it_interprets %q(
-    a = 1
-    while a != 1; end
-  ),                  [val(nil)]
+    x = 0
+    while x < 5
+      when x == 2
+        break x
+      end
+      x += 1
+    end
+  ),                  [val(2)]
 end

--- a/src/myst/interpreter/nodes/loops.cr
+++ b/src/myst/interpreter/nodes/loops.cr
@@ -1,11 +1,19 @@
 module Myst
   class Interpreter
     def visit(node : While)
+      do_loop_expression(node, inverted: false)
+    end
+
+    def visit(node : Until)
+      do_loop_expression(node, inverted: true)
+    end
+
+    private def do_loop_expression(node : Node, inverted : Bool)
       while true
         visit(node.condition)
         condition = stack.pop
 
-        if condition.truthy?
+        if (inverted ? !condition.truthy? : condition.truthy?)
           visit(node.body)
           stack.pop
         else
@@ -14,22 +22,14 @@ module Myst
       end
 
       stack.push(TNil.new)
-    end
-
-    def visit(node : Until)
-      until true
-        visit(node.condition)
-        condition = stack.pop
-
-        unless condition.truthy?
-          visit(node.body)
-          stack.pop
-        else
-          break
-        end
-      end
-
-      stack.push(TNil.new)
+    rescue ex : BreakException
+      # If a `break` appears within a loop expression, it will cause the loop to
+      # immediately terminate. Unlike `break` within a block, however, it will
+      # not propogate beyond the loop.
+      #
+      # The `Break` node that caused the `BreakException` being caught here will
+      # have already pushed the appropriate value onto the stack, so no extra
+      # work needs to be done here.
     end
   end
 end


### PR DESCRIPTION
`until` expressions now properly iterate until their condition is truthy.

As mentioned in #154, the specs for `while` and `until` weren't actually testing any of their behavior. The new specs should not be considered complete, but at least cover the basic use cases, including `break` from within a loop.

Loop expressions also now properly catch `BreakException`s to stop iteration and optionally return a value. Because `BreakException` pushes a value onto the stack, no additional work is needed to handle this case.