### PR TITLE
Fixes #155. Properly pop scope and `self` overrides when exiting an Invocation

### DIFF
--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -45,8 +45,8 @@ end
 
 # Parse and run the given program, returning the interpreter that ran the
 # program to be used for making assertions.
-def parse_and_interpret(source, interpreter=Interpreter.new)
+def parse_and_interpret(source, interpreter=Interpreter.new, capture_errors=true)
   program = parse_program(source)
-  interpreter.run(program)
+  interpreter.run(program, capture_errors: capture_errors)
   interpreter
 end

--- a/src/myst/interpreter.cr
+++ b/src/myst/interpreter.cr
@@ -6,6 +6,7 @@ module Myst
   class Interpreter
     property stack : Array(Value)
     property self_stack : Array(Value)
+    property scope_stack : Array(Scope)
     property callstack : Callstack
     property kernel : TModule
 


### PR DESCRIPTION
No matter how an Invocation is exited (implicit return, raise, break, or explicit return), `Invocation#invoke` will now _always_ pop its temporary values from the scope and self stacks of the Interpreter.

The spec added here is taken directly from #155.