### PR TITLE
Fixes #156. Fix callstack management and display.

### DIFF
--- a/spec/interpreter/callstack_spec.cr
+++ b/spec/interpreter/callstack_spec.cr
@@ -1,0 +1,355 @@
+require "../spec_helper.cr"
+require "../support/breakpoints.cr"
+
+describe "Interpreter - Callstack" do
+  it "is empty when no calls have occurred" do
+    itr = parse_and_interpret %q(
+      true
+      false
+      nil
+    )
+
+    itr.callstack.size.should eq(0)
+  end
+
+  it "is empty after all calls in a program have completed" do
+    itr = parse_and_interpret %q(
+      def bar; nil; end
+      def foo; bar; end
+      def baz; foo; end
+
+      baz
+    )
+
+    itr.callstack.size.should eq(0)
+  end
+
+
+  describe "when entering a function call" do
+    it "adds an entry to the callstack" do
+      itr = Interpreter.new
+      add_breakpoint(itr, "breakpoint") do
+        # `breakpoint` is added as a method, so calling the breakpoint itself
+        # should push an entry onto the callstack, resulting in 2 entries
+        # including `foo`.
+        itr.callstack.size.should eq(2)
+      end
+
+      parse_and_interpret! %q(
+        def foo
+          breakpoint
+        end
+
+        foo
+      ), interpreter: itr
+    end
+
+    it "uses the location of the callsite" do
+      def_location = Location.new("def_location")
+      call_location = Location.new("call_location")
+      clause = Def.new("foo", body: Call.new(nil, "breakpoint").at(call_location)).at(def_location)
+
+      itr = Interpreter.new
+      add_breakpoint(itr, "breakpoint") do
+        itr.callstack.last.location.should eq(call_location)
+      end
+
+      itr.run(clause)
+      parse_and_interpret! %q(
+        foo
+      ), interpreter: itr
+    end
+
+    it "uses the real name of the function being called" do
+      clause = Def.new("foo", body: Call.new(nil, "breakpoint"))
+
+      itr = Interpreter.new
+      add_breakpoint(itr, "breakpoint") do
+        itr.callstack.first.name.should eq("foo")
+        itr.callstack.last.name.should eq("breakpoint")
+      end
+
+      itr.run(clause)
+      parse_and_interpret! %q(
+        foo
+      ), interpreter: itr
+    end
+  end
+
+
+  describe "when leaving a function call normally" do
+    it "removes the last entry from the callstack" do
+      itr = Interpreter.new
+      add_breakpoint(itr, "breakpoint") do
+        expected_stack_size = __args[0].as(TInteger).value
+        itr.callstack.size.should eq(expected_stack_size)
+      end
+
+      parse_and_interpret! %q(
+        def foo
+          breakpoint(2)
+        end
+
+        breakpoint(1)
+        foo
+        breakpoint(1)
+      ), interpreter: itr
+    end
+
+    describe "with an explicit return" do
+      it "removes the last entry from the callstack" do
+        itr = Interpreter.new
+        add_breakpoint(itr, "breakpoint") do
+          expected_stack_size = __args[0].as(TInteger).value
+          itr.callstack.size.should eq(expected_stack_size)
+        end
+
+        parse_and_interpret! %q(
+          def foo
+            return true
+          end
+
+          foo
+          breakpoint(1)
+        ), interpreter: itr
+      end
+    end
+  end
+
+
+  describe "when leaving a block via a `break`" do
+    it "removes the `block` from the callstack" do
+      itr = Interpreter.new
+      add_breakpoint(itr, "breakpoint") do
+        expected_stack_size = __args[0].as(TInteger).value
+        itr.callstack.size.should eq(expected_stack_size)
+      end
+
+      parse_and_interpret! %q(
+        [1, 2, 3].each{ |e| breakpoint(2) }
+        breakpoint(1)
+      ), interpreter: itr
+    end
+  end
+
+
+  describe "when leaving a block via a `next`" do
+    it "removes the `next` from the callstack" do
+      itr = Interpreter.new
+      add_breakpoint(itr, "breakpoint") do
+        expected_stack_size = __args[0].as(TInteger).value
+        itr.callstack.size.should eq(expected_stack_size)
+      end
+
+      parse_and_interpret! %q(
+        def foo(&block)
+          x = 1
+          while x < 3
+            block(x)
+            breakpoint(2)
+            x += 1
+          end
+        end
+
+        foo{ |e| breakpoint(3) }
+      ), interpreter: itr
+    end
+  end
+
+
+  describe "when encountering a `raise`" do
+    it "pushes the raise callsite onto the callstack" do
+      itr = interpret_with_mocked_output %q(
+        raise "something"
+      )
+
+      itr.callstack.size.should eq(1)
+      itr.callstack.last.name.should eq("raise")
+    end
+  end
+
+
+  describe "when handling a `raise` with a `rescue`" do
+    it "pushes the rescue block location onto the callstack" do
+      itr = Interpreter.new
+      add_breakpoint(itr, "breakpoint") do
+        itr.callstack[itr.callstack.size-2].name.should eq("rescue")
+      end
+
+      parse_and_interpret! %q(
+        def foo
+          raise nil
+        rescue
+          breakpoint
+        end
+
+        foo
+      ), interpreter: itr
+    end
+
+    it "does not push rescue blocks that do not match the exception" do
+      itr = Interpreter.new
+      add_breakpoint(itr, "breakpoint") do
+        itr.callstack.context.map(&.name).should eq(["bar", "foo", "raise", "rescue", "breakpoint"])
+        itr.callstack.size.should eq(5)
+      end
+
+      parse_and_interpret! %q(
+        def foo
+          raise nil
+        rescue :not_nil
+        end
+
+        def bar
+          foo
+        rescue
+          breakpoint
+        end
+
+        bar
+      ), interpreter: itr
+    end
+
+    it "pops both the rescue and the raise when leaving the rescue normally" do
+      itr = Interpreter.new
+
+      parse_and_interpret! %q(
+        def foo
+          raise nil
+        rescue
+          nil
+        end
+
+        foo
+      ), interpreter: itr
+
+      itr.callstack.size.should eq(0)
+    end
+
+    it "pops the rescue before moving to an ensure block" do
+      itr = Interpreter.new
+      add_breakpoint(itr, "breakpoint") do
+        itr.callstack.size.should eq(3)
+        itr.callstack.context.map(&.name).should eq(["foo", "ensure", "breakpoint"])
+      end
+
+      parse_and_interpret! %q(
+        def foo
+          raise nil
+        rescue
+          nil
+        ensure
+          breakpoint
+        end
+
+        foo
+      ), interpreter: itr
+    end
+  end
+
+
+  describe "when handling an `ensure`" do
+    it "pushes the ensure block onto the callstack" do
+      itr = Interpreter.new
+      add_breakpoint(itr, "breakpoint") do
+        itr.callstack[itr.callstack.size-2].name.should eq("ensure")
+      end
+
+      parse_and_interpret! %q(
+        def foo
+          raise nil
+        ensure
+          breakpoint
+        end
+
+        def bar
+          foo
+        rescue
+          nil
+        end
+
+        bar
+      ), interpreter: itr
+    end
+
+    it "pops the ensure block when leaving normally" do
+      itr = Interpreter.new
+      add_breakpoint(itr, "breakpoint") do
+      end
+
+      parse_and_interpret! %q(
+        def foo
+        ensure
+          nil
+        end
+
+        foo
+      ), interpreter: itr
+
+      itr.callstack.size.should eq(0)
+    end
+  end
+
+
+  describe "when raising an error from an exception handler" do
+    it "leaves the rescue on the stack" do
+      itr = Interpreter.new
+      add_breakpoint(itr, "breakpoint") do
+        itr.callstack.context.map(&.name).should eq([
+          "bar",
+          "foo",
+          "raise",
+          "rescue",
+          "raise",
+          "rescue",
+          "breakpoint"
+        ])
+      end
+
+      parse_and_interpret! %q(
+        def foo
+          raise :one
+        rescue
+          raise :two
+        end
+
+        def bar
+          foo
+        rescue :two
+          breakpoint
+        end
+
+        bar
+      ), interpreter: itr
+    end
+
+    it "leaves the ensure on the stack" do
+      itr = Interpreter.new
+      add_breakpoint(itr, "breakpoint") do
+        itr.callstack.context.map(&.name).should eq([
+          "bar",
+          "foo",
+          "ensure",
+          "raise",
+          "rescue",
+          "breakpoint"
+        ])
+      end
+
+      parse_and_interpret! %q(
+        def foo
+        ensure
+          raise :two
+        end
+
+        def bar
+          foo
+        rescue :two
+          breakpoint
+        end
+
+        bar
+      ), interpreter: itr
+    end
+  end
+end

--- a/spec/interpreter/invocation_spec.cr
+++ b/spec/interpreter/invocation_spec.cr
@@ -153,7 +153,7 @@ describe "Interpreter - Invocation" do
     # `foo` is resumed after calling `bar`, the lookup of `b` fails, as the
     # `current_scope` is still the local scope override of `bar`, which has no
     # entry with the name `b`.
-    parse_and_interpret %q(
+    parse_and_interpret! %q(
       def bar(a)
         return a
       end
@@ -164,7 +164,7 @@ describe "Interpreter - Invocation" do
       end
 
       foo(1, 3)
-    ), interpreter: itr, capture_errors: false
+    ), interpreter: itr
 
     itr.self_stack.size.should eq(1)
     itr.current_self.should eq(original_self)

--- a/spec/interpreter/nodes/def_spec.cr
+++ b/spec/interpreter/nodes/def_spec.cr
@@ -4,46 +4,46 @@ require "../../support/interpret.cr"
 
 describe "Interpreter - Def" do
   # The result of a `def` should always be the function that was defined.
-  it_interprets %q(def foo; end)  { |itr| [TFunctor.new([TFunctorDef.new(Def.new("foo"))] of Callable, itr.current_scope)] }
+  it_interprets %q(def foo; end)  { |itr| [TFunctor.new("foo", [TFunctorDef.new(Def.new("foo"))] of Callable, itr.current_scope)] }
   it_interprets %q(
     def foo
       []
     end
-  )                               { |itr| [TFunctor.new([TFunctorDef.new(Def.new("foo", body: e(ListLiteral.new)))] of Callable, itr.current_scope)] }
+  )                               { |itr| [TFunctor.new("foo", [TFunctorDef.new(Def.new("foo", body: e(ListLiteral.new)))] of Callable, itr.current_scope)] }
   it_interprets %q(
     def foo
       true
       nil
       1
     end
-  )                               { |itr| [TFunctor.new([TFunctorDef.new(Def.new("foo", body: e(l(true), l(nil), l(1))))] of Callable, itr.current_scope)] }
+  )                               { |itr| [TFunctor.new("foo", [TFunctorDef.new(Def.new("foo", body: e(l(true), l(nil), l(1))))] of Callable, itr.current_scope)] }
 
   it_interprets %q(
     def foo(a)
       a
     end
-  )                               { |itr| [TFunctor.new([TFunctorDef.new(Def.new("foo", [p("a")], body: e(Var.new("a"))))] of Callable, itr.current_scope)] }
+  )                               { |itr| [TFunctor.new("foo", [TFunctorDef.new(Def.new("foo", [p("a")], body: e(Var.new("a"))))] of Callable, itr.current_scope)] }
 
   # Redefinition of a function is allowed. It will simply create a second clause.
   it_interprets %q(
     def foo; end
     def foo; end
-  )                               { |itr| [TFunctor.new([TFunctorDef.new(Def.new("foo")), TFunctorDef.new(Def.new("foo"))] of Callable, itr.current_scope)] }
+  )                               { |itr| [TFunctor.new("foo", [TFunctorDef.new(Def.new("foo")), TFunctorDef.new(Def.new("foo"))] of Callable, itr.current_scope)] }
 
   it_interprets %q(
     def foo(a); end
     def foo(b); end
-  )                               { |itr| [TFunctor.new([TFunctorDef.new(Def.new("foo", [p("a")])), TFunctorDef.new(Def.new("foo", [p("b")]))] of Callable, itr.current_scope)] }
+  )                               { |itr| [TFunctor.new("foo", [TFunctorDef.new(Def.new("foo", [p("a")])), TFunctorDef.new(Def.new("foo", [p("b")]))] of Callable, itr.current_scope)] }
 
   # Functions with different names should not be merged into one functor.
   it_interprets %q(
     def a; end
     def b; end
-  )                               { |itr| [TFunctor.new([TFunctorDef.new(Def.new("b"))] of Callable, itr.current_scope)] }
+  )                               { |itr| [TFunctor.new("b", [TFunctorDef.new(Def.new("b"))] of Callable, itr.current_scope)] }
 
   it "only checks the current scope for existing functors" do
     itr = Interpreter.new
-    itr.current_scope["foo"] = TFunctor.new([] of Callable, itr.current_scope)
+    itr.current_scope["foo"] = TFunctor.new("foo", [] of Callable, itr.current_scope)
     itr.push_self(TModule.new)
     # With the new scope, the current scope does not have `foo` defined.
     itr.current_scope.has_key?("foo").should be_false

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -50,3 +50,8 @@ def parse_and_interpret(source, interpreter=Interpreter.new, capture_errors=true
   interpreter.run(program, capture_errors: capture_errors)
   interpreter
 end
+
+# Same as `parse_and_interpret`, but force errors to propogate out.
+def parse_and_interpret!(source, interpreter=Interpreter.new)
+  parse_and_interpret(source, interpreter, capture_errors: false)
+end

--- a/spec/support/breakpoints.cr
+++ b/spec/support/breakpoints.cr
@@ -36,5 +36,5 @@ macro add_breakpoint(itr, name)
     %result.is_a?(Myst::Value) ? %result : TNil.new.as(Myst::Value)
   end
 
-  {{itr}}.kernel.scope[{{name}}] = TFunctor.new([%handler] of Callable)
+  {{itr}}.kernel.scope[{{name}}] = TFunctor.new({{name}}, [%handler] of Callable)
 end

--- a/spec/support/breakpoints.cr
+++ b/spec/support/breakpoints.cr
@@ -1,0 +1,40 @@
+# This file defines ways of pausing execution of Myst code to allow specs to
+# make assertions while running, rather than waiting until afterward. This is
+# especially helpful for testing things like `self` values, scoping, and
+# callstack management, where after execution the respective stacks for these
+# values will be empty.
+require "../spec_helper.cr"
+
+# Add a special method to the Kernel of the given interpreter that runs the
+# given handler block when encountered in a program. This method will be
+# available like any normal method in Myst, and can accept any arbitrary set
+# of parameters for testing. See `NativeLib.method` for more details.
+#
+# The handler block will have three variables made available:
+#   - A `this` parameter representing `self` at the time of the call
+#   - An `__args` parameter representing the normal arguments to the call
+#   - A `block` parameter representing the optional block argument
+#
+# Example:
+#
+#   itr = Interpreter.new
+#   add_breakpoint(itr, "breakpoint") do |this, args, block|
+#     args[0].should be_a(TInteger)
+#   end
+#
+#   parse_and_interpret %q(
+#     [1, 2, 3].each do |e|
+#       breakpoint(e)
+#     end
+#   ), interpreter: itr
+macro add_breakpoint(itr, name)
+  %handler = ->(this : Myst::Value, __args : Array(Myst::Value), block : TFunctor?) do
+    %result = begin
+      {{ yield }}
+    end
+
+    %result.is_a?(Myst::Value) ? %result : TNil.new.as(Myst::Value)
+  end
+
+  {{itr}}.kernel.scope[{{name}}] = TFunctor.new([%handler] of Callable)
+end

--- a/spec/support/interpret.cr
+++ b/spec/support/interpret.cr
@@ -46,9 +46,11 @@ def it_interprets_with_assignments(node : String, assignments : Hash(String, Mys
   end
 end
 
-def interpret_with_mocked_output(source)
-  itr = Interpreter.new(output: IO::Memory.new, input: IO::Memory.new, errput: IO::Memory.new)
-  parse_and_interpret(source, itr)
+def interpret_with_mocked_output(source, interpreter=Interpreter.new)
+  interpreter.output  = IO::Memory.new
+  interpreter.input   = IO::Memory.new
+  interpreter.errput  = IO::Memory.new
+  parse_and_interpret(source, interpreter)
 end
 
 def interpret_with_mocked_input(source, input)

--- a/src/myst/interpreter.cr
+++ b/src/myst/interpreter.cr
@@ -71,6 +71,16 @@ module Myst
     end
 
 
+    def pop_callstack(to_size : Int)
+      return unless to_size >= 0
+
+      count_to_pop = @callstack.size - to_size
+      if count_to_pop > 0
+        @callstack.pop(count_to_pop)
+      end
+    end
+
+
     def current_self
       self_stack.last
     end
@@ -111,13 +121,7 @@ module Myst
       value_to_s = __scopeof(error.value)["to_s"].as(TFunctor)
       result = Invocation.new(self, value_to_s, error.value, [] of Value, nil).invoke
       errput.puts("Uncaught Exception: " + result.as(TString).value)
-      error.trace.reverse_each do |frame|
-        if frame.responds_to?(:name)
-          errput.puts "  from `#{frame.name}` at #{frame.location}"
-        else
-          errput.puts "  at #{frame.location}"
-        end
-      end
+      errput.puts(error.trace)
     end
 
     def run(program, capture_errors=true)
@@ -133,13 +137,7 @@ module Myst
       errput.puts("Interpreter Error: #{ex.message}")
       errput.puts
       errput.puts("Myst backtrace: ")
-      callstack.reverse_each do |frame|
-        if frame.responds_to?(:name)
-          errput.puts "  from `#{frame.name}` at #{frame.location}"
-        else
-          errput.puts "  at #{frame.location}"
-        end
-      end
+      errput.puts(callstack)
       errput.puts
       errput.puts("Native backtrace: ")
       errput.puts(ex.inspect_with_backtrace)

--- a/src/myst/interpreter.cr
+++ b/src/myst/interpreter.cr
@@ -129,6 +129,7 @@ module Myst
         raise err
       end
     rescue ex
+      raise ex unless capture_errors
       errput.puts("Interpreter Error: #{ex.message}")
       errput.puts
       errput.puts("Myst backtrace: ")

--- a/src/myst/interpreter/callstack.cr
+++ b/src/myst/interpreter/callstack.cr
@@ -1,10 +1,64 @@
 module Myst
   struct Callstack
-    property context : Array(Node)
+    record Entry,
+      location : Location?,
+      name : String?
 
-    def initialize(@context = [] of Node)
+    property context : Array(Entry)
+
+    def initialize(@context = [] of Entry)
     end
 
-    delegate reverse_each, push, pop, to: context
+    def to_s(io : IO)
+      context.reverse_each do |c|
+        location = c.location.try(&.to_s(colorize: true))
+        # colorize special names
+        name =
+          case n = c.name
+          when "raise"
+            n.colorize(:red)
+          when "rescue", "ensure"
+            n.colorize(:green)
+          else
+            n
+          end.to_s
+
+        case {name, location}
+        when {String, String}
+          io << "  in `#{name}` at #{location}\n"
+        when {nil, String}
+          io << "  at #{location}\n"
+        when {String, nil}
+          io << "  in `#{name}` (no location info available)\n"
+        when {nil, nil}
+          io << "  at an unknown frame\n"
+        else
+          puts typeof(name)
+          puts typeof(location)
+        end
+      end
+    end
+
+    def push(entry : Entry)
+      @context.push(entry)
+    end
+
+    def push(location : Location?, name : String?=nil)
+      @context.push(Entry.new(location, name))
+    end
+
+    def [](index)
+      @context[index]
+    end
+
+    def []?(index)
+      @context[index]?
+    end
+
+    def []=(index, value : Entry)
+      @context[index] = value
+    end
+
+    delegate first, last, size, reverse_each, pop, to: context
   end
 end

--- a/src/myst/interpreter/native_lib.cr
+++ b/src/myst/interpreter/native_lib.cr
@@ -45,13 +45,13 @@ module Myst
     end
 
     macro def_method(type, name, impl_name)
-      {{type}}.scope["{{name.id}}"] = TFunctor.new([
+      {{type}}.scope["{{name.id}}"] = TFunctor.new("{{name.id}}", [
         ->{{impl_name.id}}(Value, Array(Value), TFunctor?).as(Callable)
       ] of Callable)
     end
 
     macro def_instance_method(type, name, impl_name)
-      {{type}}.instance_scope["{{name.id}}"] = TFunctor.new([
+      {{type}}.instance_scope["{{name.id}}"] = TFunctor.new("{{name.id}}", [
         ->{{impl_name.id}}(Value, Array(Value), TFunctor?).as(Callable)
       ] of Callable)
     end

--- a/src/myst/interpreter/nodes/anonymous_function.cr
+++ b/src/myst/interpreter/nodes/anonymous_function.cr
@@ -14,7 +14,7 @@ module Myst
           current_scope
         end
 
-      functor = TFunctor.new([] of Callable, scope, closure: true, closed_self: current_self)
+      functor = TFunctor.new("anonymous function", [] of Callable, scope, closure: true, closed_self: current_self)
 
       node.clauses.each do |clause|
         functor.add_clause(TFunctorDef.new(clause))

--- a/src/myst/interpreter/nodes/call.cr
+++ b/src/myst/interpreter/nodes/call.cr
@@ -3,7 +3,6 @@ module Myst
     def visit(node : Call)
       receiver, func = lookup_call(node)
 
-      @callstack.push(node)
       if func
         visit_call(node, receiver, func)
       else
@@ -14,7 +13,6 @@ module Myst
           raise "Interpreter bug: "
         end
       end
-      @callstack.pop
     end
 
 
@@ -73,7 +71,10 @@ module Myst
         block = stack.pop.as(TFunctor)
       end
 
+      original_callstack_size = @callstack.size
+      @callstack.push(node.location, func.name)
       result = Invocation.new(self, func, receiver, args, block).invoke
+      pop_callstack(to_size: original_callstack_size)
       stack.push(result)
     end
 

--- a/src/myst/interpreter/nodes/def.cr
+++ b/src/myst/interpreter/nodes/def.cr
@@ -23,11 +23,11 @@ module Myst
         if scope.has_key?(node.name)
           functor = scope[node.name].as(TFunctor)
         else
-          functor = TFunctor.new([] of Callable, scope, closure: false)
+          functor = TFunctor.new(node.name, [] of Callable, scope, closure: false)
           scope.assign(node.name, functor)
         end
       else
-        functor = TFunctor.new([] of Callable, scope, closure: true, closed_self: current_self)
+        functor = TFunctor.new("block", [] of Callable, scope, closure: true, closed_self: current_self)
       end
 
       functor.add_clause(TFunctorDef.new(node))

--- a/src/myst/interpreter/nodes/raise.cr
+++ b/src/myst/interpreter/nodes/raise.cr
@@ -4,6 +4,7 @@ module Myst
       visit(node.value)
       value = stack.pop
 
+      @callstack.push(node.location, "raise")
       __raise_runtime_error(value)
     end
   end

--- a/src/myst/interpreter/nodes/references.cr
+++ b/src/myst/interpreter/nodes/references.cr
@@ -23,7 +23,6 @@ module Myst
       if value = (current_scope[node.name]? || __typeof(current_self).scope[node.name]? || recursive_lookup(current_self, node.name))
         stack.push(value)
       else
-        @callstack.push(node)
         __raise_not_found(node.name, current_self)
       end
     end

--- a/src/myst/interpreter/util.cr
+++ b/src/myst/interpreter/util.cr
@@ -52,7 +52,6 @@ module Myst
       if value = current_scope[node.name]?
         value
       else
-        @callstack.push(node)
         __raise_not_found(node.name, current_self)
       end
     end

--- a/src/myst/interpreter/value.cr
+++ b/src/myst/interpreter/value.cr
@@ -81,7 +81,7 @@ module Myst
       @instance_scope = Scope.new(parent)
       # TODO: revist this when base object for TType is in place
       # Currently this prevents to_s from being overriden on Types
-      @scope["to_s"] = TFunctor.new([
+      @scope["to_s"] = TFunctor.new("to_s", [
         ->ttype_to_s(Value, Array(Value), TFunctor?)] of Callable)
     end
 
@@ -305,12 +305,13 @@ module Myst
   # A Functor is a container for multiple functor definitions, which can either
   # be language-level or native.
   class TFunctor < Value
+    property  name            : String
     property  clauses         : Array(Callable)
     property  lexical_scope   : Scope
     property? closure         : Bool
-    property!  closed_self     : Value?
+    property! closed_self     : Value?
 
-    def initialize(@clauses=[] of Callable, @lexical_scope : Scope=Scope.new, @closure : Bool=false, @closed_self : Value?=nil)
+    def initialize(@name : String, @clauses=[] of Callable, @lexical_scope : Scope=Scope.new, @closure : Bool=false, @closed_self : Value?=nil)
     end
 
     def add_clause(definition : Callable)
@@ -325,6 +326,6 @@ module Myst
       closure? ? ClosureScope.new(@lexical_scope) : Scope.new(@lexical_scope)
     end
 
-    def_equals_and_hash clauses, lexical_scope
+    def_equals_and_hash name, clauses, lexical_scope
   end
 end

--- a/src/myst/syntax/lexer.cr
+++ b/src/myst/syntax/lexer.cr
@@ -565,7 +565,7 @@ module Myst
       end
 
       case @reader.buffer_value
-      when "__FILE__" 
+      when "__FILE__"
         @current_token.type = Token::Type::MAGIC_FILE
       when "__LINE__"
         @current_token.type = Token::Type::MAGIC_LINE

--- a/src/myst/syntax/location.cr
+++ b/src/myst/syntax/location.cr
@@ -13,9 +13,9 @@ module Myst
     def to_s(colorize=false)
       was_coloring = Colorize.enabled?
       Colorize.enabled = colorize
-      location_str =  "#{@file || "anonymous"}".colorize(:red).to_s +
+      location_str =  "#{@file || "anonymous"}".colorize(:dark_gray).to_s +
                       ":#{@line}".colorize(:blue).to_s +
-                      ":#{@col}".colorize(:dark_gray).to_s
+                      ":#{@col}".colorize(:dark_gray).mode(:dim).to_s
       Colorize.enabled = was_coloring
       location_str
     end

--- a/src/myst/syntax/parser.cr
+++ b/src/myst/syntax/parser.cr
@@ -450,14 +450,14 @@ module Myst
     def parse_flow_control
       node =
         case
-        when accept(Token::Type::RETURN)
-          Return.new
-        when accept(Token::Type::BREAK)
-          Break.new
-        when accept(Token::Type::NEXT)
-          Next.new
-        when accept(Token::Type::RAISE)
-          Raise.new
+        when token = accept(Token::Type::RETURN)
+          Return.new.at(token.location)
+        when token = accept(Token::Type::BREAK)
+          Break.new.at(token.location)
+        when token = accept(Token::Type::NEXT)
+          Next.new.at(token.location)
+        when token = accept(Token::Type::RAISE)
+          Raise.new.at(token.location)
         else
           raise ParseError.new(current_location, "Expected one of return, break, or next, got #{current_token.inspect}")
         end


### PR DESCRIPTION
This PR overhauls how the callstack is managed throughout the interpreter, hopefully fixing #156 and preventing unwanted leaks from `raise`, `return`, etc.

To accomplish this, this commit also adds a few other changes:

- Add missing location information to flow control nodes while parsing.
- Add a `name` property to `TFunctor` objects, used for display in backtraces.
- Improve colorization of callstack output.
- Add `add_breakpoint` for for executing arbitrary Crystal code during execution of a Myst program in Specs.