### PR TITLE
Fixes #168. Allow top-level expressions as right-side of logicals.

### DIFF
--- a/spec/myst/assert_spec.mt
+++ b/spec/myst/assert_spec.mt
@@ -1,7 +1,7 @@
 require "stdlib/spec.mt"
 
 def test_assert(value)
-  value || (raise "Test Assertion Failed.")
+  value || raise "Test Assertion Failed."
 end
 
 def test_raises(&block)

--- a/stdlib/assert.mt
+++ b/stdlib/assert.mt
@@ -37,7 +37,7 @@ defmodule Assert
     #
     # Asserts that the value is truthy (not `false` or `nil`).
     def is_truthy
-      @value || (raise %AssertionFailure{@value, true, "truthy"})
+      @value || raise %AssertionFailure{@value, true, "truthy"}
       self
     end
 
@@ -45,7 +45,7 @@ defmodule Assert
     #
     # Asserts that the value is falsey (either `false` or `nil`).
     def is_falsey
-      @value && (raise %AssertionFailure{@value, false, "falsey"})
+      @value && raise %AssertionFailure{@value, false, "falsey"}
       self
     end
 
@@ -53,7 +53,7 @@ defmodule Assert
     #
     # Asserts that the value is exactly the boolean value `true`.
     def is_true
-      @value == true || (raise %AssertionFailure{@value, true, "exactly true"})
+      @value == true || raise %AssertionFailure{@value, true, "exactly true"}
       self
     end
 
@@ -61,7 +61,7 @@ defmodule Assert
     #
     # Asserts that the value is exactly the boolean value `false`.
     def is_false
-      @value == false || (raise %AssertionFailure{@value, false, "exactly false"})
+      @value == false || raise %AssertionFailure{@value, false, "exactly false"}
       self
     end
 
@@ -69,7 +69,7 @@ defmodule Assert
     #
     # Asserts that the value is `nil` (false is not allowed).
     def is_nil
-      @value == nil || (raise %AssertionFailure{@value, nil, "nil"})
+      @value == nil || raise %AssertionFailure{@value, nil, "nil"}
       self
     end
 
@@ -77,7 +77,7 @@ defmodule Assert
     #
     # Asserts that the value is not `nil` (false is allowed).
     def is_not_nil
-      @value != nil || (raise %AssertionFailure{@value, nil, "not nil"})
+      @value != nil || raise %AssertionFailure{@value, nil, "not nil"}
       self
     end
 


### PR DESCRIPTION
Addressing the bug from #168, the parser now allows `raise`, `break`, `next`, and `return` expressions to appear on the right-side of a logical expression.

Similar to infix assignments, flow control expressions "take over" the expression, and subsequent components of the expression will be parsed as the value of the control expression, rather than the parent. See the added specs for more details.