### PR TITLE
Run Travis builds on both Linux and OS X

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,13 @@
 language: crystal
-
 script: make spec
+
+os:
+  - linux
+  - osx
+crystal:
+  - latest
+  - nightly
+  
+matrix:
+  allow_failures:
+  - crystal: nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,9 @@ script: make spec
 
 os:
   - linux
-  - osx
+  # TODO: Re-add OS X when Travis improves run times.
+  # Alternatively: introduce OS X builds only on master, not on PRs
+  # - osx
 crystal:
   - latest
   - nightly


### PR DESCRIPTION
Travis will now build Myst on both Linux and OS X. It will also test against the latest release of crystal, as well as the nightly, to hopefully catch any potential future problems before they are released in Crystal.

Builds on the nightly version of Crystal are allowed to fail.