### PR TITLE
Closes #173. Implement a base type, `Type` + various methods and fixes

### DIFF
--- a/spec/interpreter/closure_scope_spec.cr
+++ b/spec/interpreter/closure_scope_spec.cr
@@ -96,7 +96,7 @@ describe "Interpreter - ClosureScope" do
     it "removes all entries from the scope" do
       scope = ClosureScope.new(Scope.new)
       scope["a"] = TNil.new
-      scope["Thing"] = TType.new("Thing")
+      scope["Thing"] = TType.new("Thing", nil, nil)
       scope["x"] = 100_i64
 
       scope.values.size.should eq(3)

--- a/spec/interpreter/matcher_spec.cr
+++ b/spec/interpreter/matcher_spec.cr
@@ -138,7 +138,7 @@ describe "Interpreter - #match" do
       # end
       itr = Interpreter.new
       mod_foo   = TModule.new("Foo")
-      type_bar  = TType.new("Bar")
+      type_bar  = TType.new("Bar", nil)
       type_bar.insert_ancestor(mod_foo)
 
       itr.current_scope.assign("Foo", mod_foo)
@@ -151,7 +151,7 @@ describe "Interpreter - #match" do
       itr = Interpreter.new
       mod_foo   = TModule.new("Foo")
       mod_bar   = TModule.new("Bar")
-      type_baz  = TType.new("Baz")
+      type_baz  = TType.new("Baz", nil)
       mod_bar.insert_ancestor(mod_foo)
       type_baz.insert_ancestor(mod_bar)
 
@@ -167,7 +167,7 @@ describe "Interpreter - #match" do
       itr = Interpreter.new
       mod_foo   = TModule.new("Foo")
       mod_bar   = TModule.new("Bar")
-      type_baz  = TType.new("Baz")
+      type_baz  = TType.new("Baz", nil)
       type_baz.insert_ancestor(mod_foo)
       type_baz.insert_ancestor(mod_bar)
 
@@ -181,7 +181,7 @@ describe "Interpreter - #match" do
       # end
       itr = Interpreter.new
       mod_foo   = TModule.new("Foo")
-      type_bar  = TType.new("Bar")
+      type_bar  = TType.new("Bar", nil)
       type_bar.extend_module(mod_foo)
 
       itr.current_scope.assign("Foo", mod_foo)

--- a/spec/interpreter/nodes/type_def_spec.cr
+++ b/spec/interpreter/nodes/type_def_spec.cr
@@ -17,7 +17,7 @@ describe "Interpreter - TypeDef" do
     end
   ) do |typ, itr|
     typ.should be_a(Myst::TType)
-    typ.scope.values.size.should eq(1)
+    typ.scope.values.size.should eq(0)
     typ.scope.parent.should eq(itr.current_scope)
   end
 

--- a/spec/interpreter/scope_spec.cr
+++ b/spec/interpreter/scope_spec.cr
@@ -70,7 +70,7 @@ describe "Interpreter - Scope" do
     it "removes all entries from the scope" do
       scope = Scope.new
       scope["a"] = TNil.new
-      scope["Thing"] = TType.new("Thing")
+      scope["Thing"] = TType.new("Thing", nil)
       scope["x"] = 100_i64
 
       scope.values.size.should eq(3)

--- a/spec/myst/assert_spec.mt
+++ b/spec/myst/assert_spec.mt
@@ -7,7 +7,7 @@ end
 def test_raises(&block)
   block()
 rescue ex
-  test_assert(ex.type.to_s == "AssertionFailure")
+  test_assert(ex.type == Assert.AssertionFailure)
 end
 
 describe("Assert") do
@@ -17,11 +17,11 @@ describe("Assert") do
 
     describe("#is_truthy") do
       it("returns the assertion object when the assertion succeeds") do
-        test_assert(true_subject.is_truthy.type.to_s == "Assertion")
+        test_assert(true_subject.is_truthy.type == Assert.Assertion)
       end
 
       it("passes when the value is anything truthy") do
-        test_assert(assert([]).is_truthy.type.to_s == "Assertion")
+        test_assert(assert([]).is_truthy.type == Assert.Assertion)
       end
 
       it("raises an AssertionFailure if the value is not truthy") do
@@ -31,12 +31,12 @@ describe("Assert") do
 
     describe("#is_falsey") do
       it("returns the assertion object when the assertion succeeds") do
-        test_assert(false_subject.is_falsey.type.to_s == "Assertion")
+        test_assert(false_subject.is_falsey.type == Assert.Assertion)
       end
 
 
       it("passes when the value is anything nil") do
-        test_assert(assert(nil).is_falsey.type.to_s == "Assertion")
+        test_assert(assert(nil).is_falsey.type == Assert.Assertion)
       end
 
       it("raises an AssertionFailure if the value is not truthy") do
@@ -46,7 +46,7 @@ describe("Assert") do
 
     describe("#is_true") do
       it("returns the assertion object when the assertion succeeds") do
-        test_assert(true_subject.is_true.type.to_s == "Assertion")
+        test_assert(true_subject.is_true.type == Assert.Assertion)
       end
 
       it("does not pass unless the value is exactly `true`") do
@@ -60,7 +60,7 @@ describe("Assert") do
 
     describe("#is_false") do
       it("returns the assertion object when the assertion succeeds") do
-        test_assert(false_subject.is_false.type.to_s == "Assertion")
+        test_assert(false_subject.is_false.type == Assert.Assertion)
       end
 
       it("does not pass unless the value is exactly `false`") do
@@ -74,7 +74,7 @@ describe("Assert") do
 
     describe("#is_nil") do
       it("returns the assertion object when the assertion succeeds") do
-        test_assert(assert(nil).is_nil.type.to_s == "Assertion")
+        test_assert(assert(nil).is_nil.type == Assert.Assertion)
       end
 
       it("raises an AssertionFailure if the value is not `nil`") do
@@ -84,11 +84,11 @@ describe("Assert") do
 
     describe("#is_not_nil") do
       it("returns the assertion object when the assertion succeeds") do
-        test_assert(assert(true).is_not_nil.type.to_s == "Assertion")
+        test_assert(assert(true).is_not_nil.type == Assert.Assertion)
       end
 
       it("passes when the value is `false`") do
-        test_assert(assert(false).is_not_nil.type.to_s == "Assertion")
+        test_assert(assert(false).is_not_nil.type == Assert.Assertion)
       end
 
       it("raises an AssertionFailure if the value is `nil`") do
@@ -99,7 +99,7 @@ describe("Assert") do
 
     describe("#equals") do
       it("returns the assertion object when the assertion succeeds") do
-        test_assert(assert(true).equals(true).type.to_s == "Assertion")
+        test_assert(assert(true).equals(true).type == Assert.Assertion)
       end
 
       it("raises an AssertionFailure if the value is not equal to its argument") do
@@ -109,7 +109,7 @@ describe("Assert") do
 
     describe("#does_not_equal") do
       it("returns the assertion object when the assertion succeeds") do
-        test_assert(assert(true).does_not_equal(false).type.to_s == "Assertion")
+        test_assert(assert(true).does_not_equal(false).type == Assert.Assertion)
       end
 
       it("raises an AssertionFailure if the value is equal to its argument") do
@@ -120,7 +120,7 @@ describe("Assert") do
 
     describe("#less_than") do
       it("returns the assertion object when the assertion succeeds") do
-        test_assert(assert(1).less_than(2).type.to_s == "Assertion")
+        test_assert(assert(1).less_than(2).type == Assert.Assertion)
       end
 
       it("does not pass when the values are equal") do
@@ -134,11 +134,11 @@ describe("Assert") do
 
     describe("#less_or_equal") do
       it("returns the assertion object when the assertion succeeds") do
-        test_assert(assert(1).less_or_equal(2).type.to_s == "Assertion")
+        test_assert(assert(1).less_or_equal(2).type == Assert.Assertion)
       end
 
       it("passes when the values are equal") do
-        test_assert(assert(1).less_or_equal(1).type.to_s == "Assertion")
+        test_assert(assert(1).less_or_equal(1).type == Assert.Assertion)
       end
 
       it("raises an AssertionFailure if the value is not less or equal than its argument") do
@@ -148,11 +148,11 @@ describe("Assert") do
 
     describe("#greater_or_equal") do
       it("returns the assertion object when the assertion succeeds") do
-        test_assert(assert(2).greater_or_equal(1).type.to_s == "Assertion")
+        test_assert(assert(2).greater_or_equal(1).type == Assert.Assertion)
       end
 
       it("passes when the values are equal") do
-        test_assert(assert(1).greater_or_equal(1).type.to_s == "Assertion")
+        test_assert(assert(1).greater_or_equal(1).type == Assert.Assertion)
       end
 
       it("raises an AssertionFailure if the value is not greater or equal than its argument") do
@@ -162,7 +162,7 @@ describe("Assert") do
 
     describe("#greater_than") do
       it("returns the assertion object when the assertion succeeds") do
-        test_assert(assert(2).greater_than(1).type.to_s == "Assertion")
+        test_assert(assert(2).greater_than(1).type == Assert.Assertion)
       end
 
       it("does not pass when the values are equal") do
@@ -177,7 +177,7 @@ describe("Assert") do
 
     describe("#between") do
       it("returns the assertion object when the assertion succeeds") do
-        test_assert(assert(1).between(0, 2).type.to_s == "Assertion")
+        test_assert(assert(1).between(0, 2).type == Assert.Assertion)
       end
 
       it("passes when the value is equal to the lower argument") do
@@ -196,7 +196,7 @@ describe("Assert") do
 
     describe("#<") do
       it("acts like #less_than") do
-        test_assert(assert(1).less_than(2).type.to_s == "Assertion")
+        test_assert(assert(1).less_than(2).type == Assert.Assertion)
         test_raises{ assert(1).less_than(1) }
         test_raises{ assert(2).less_than(1) }
       end
@@ -204,37 +204,37 @@ describe("Assert") do
 
     describe("#<=") do
       it("acts like #less_or_equal") do
-        test_assert(assert(1).less_or_equal(2).type.to_s == "Assertion")
-        test_assert(assert(1).less_or_equal(1).type.to_s == "Assertion")
+        test_assert(assert(1).less_or_equal(2).type == Assert.Assertion)
+        test_assert(assert(1).less_or_equal(1).type == Assert.Assertion)
         test_raises{ assert(2).less_or_equal(1) }
       end
     end
 
     describe("#==") do
       it("acts like #equals") do
-        test_assert(assert(true).equals(true).type.to_s == "Assertion")
+        test_assert(assert(true).equals(true).type == Assert.Assertion)
         test_raises{ assert(true).equals(false) }
       end
     end
 
     describe("#!=") do
       it("acts like #does_not_equal") do
-        test_assert(assert(true).does_not_equal(false).type.to_s == "Assertion")
+        test_assert(assert(true).does_not_equal(false).type == Assert.Assertion)
         test_raises{ assert(true).equals(true) }
       end
     end
 
     describe("#>=") do
       it("acts like #greater_or_equal") do
-        test_assert(assert(2).greater_or_equal(1).type.to_s == "Assertion")
-        test_assert(assert(1).greater_or_equal(1).type.to_s == "Assertion")
+        test_assert(assert(2).greater_or_equal(1).type == Assert.Assertion)
+        test_assert(assert(1).greater_or_equal(1).type == Assert.Assertion)
         test_raises{ assert(1).greater_or_equal(2) }
       end
     end
 
     describe("#>") do
       it("acts like #greater_than") do
-        test_assert(assert(2).greater_than(1).type.to_s == "Assertion")
+        test_assert(assert(2).greater_than(1).type == Assert.Assertion)
         test_raises{ assert(1).greater_than(1) }
         test_raises{ assert(1).greater_than(1) }
       end
@@ -250,7 +250,7 @@ describe("Assert") do
     describe("#raises") do
       describe("with no arguments") do
         it("returns the blockassertion object when the block raises any error") do
-          test_assert(raising_subject.raises.type.to_s == "BlockAssertion")
+          test_assert(raising_subject.raises.type == Assert.BlockAssertion)
         end
 
         it("raises an AssertionFailure when the block does not raise an error") do
@@ -260,7 +260,7 @@ describe("Assert") do
 
       describe("with an error argument") do
         it("returns the blockassertion object if the block raises the given error") do
-          test_assert(raising_subject.raises(:foo).type.to_s == "BlockAssertion")
+          test_assert(raising_subject.raises(:foo).type == Assert.BlockAssertion)
         end
 
         it("raises an AssertionFailure when the block does not raise an error") do
@@ -275,7 +275,7 @@ describe("Assert") do
 
     describe("#succeeds") do
       it("returns the blockassertion object when the block does not raise an error") do
-        test_assert(passing_subject.succeeds.type.to_s == "BlockAssertion")
+        test_assert(passing_subject.succeeds.type == Assert.BlockAssertion)
       end
 
       it("raises an AssertionFailure when the block does raise an error") do
@@ -285,7 +285,7 @@ describe("Assert") do
 
     describe("#returns") do
       it("returns the blockassertion object when the block returns the expected value") do
-        test_assert(passing_subject.returns(:passing).type.to_s == "BlockAssertion")
+        test_assert(passing_subject.returns(:passing).type == Assert.BlockAssertion)
       end
 
       it("raises an AssertionFailure when the block does not return the expected value") do

--- a/spec/myst/file_spec.mt
+++ b/spec/myst/file_spec.mt
@@ -5,7 +5,7 @@ describe("File") do
   describe(".open") do
     it("returns a new File instance for the given file") do
       file = File.open("spec/support/misc/fixed_size_file.txt", "r")
-      assert(file.type.to_s).equals("File")
+      assert(file).is_a(File)
     end
 
     it("defaults to 'read' mode if no mode is given") do

--- a/spec/myst/file_spec.mt
+++ b/spec/myst/file_spec.mt
@@ -5,7 +5,6 @@ describe("File") do
   describe(".open") do
     it("returns a new File instance for the given file") do
       file = File.open("spec/support/misc/fixed_size_file.txt", "r")
-
       assert(file.type.to_s).equals("File")
     end
 

--- a/spec/myst/random_spec.mt
+++ b/spec/myst/random_spec.mt
@@ -4,7 +4,7 @@ describe("Random") do
   describe("#rand") do
     describe("without arguments") do
       it("returns a Float value") do
-        assert(Random.rand.type.to_s).equals("Float")
+        assert(Random.rand).is_a(Float)
       end
 
       it("returns a value in the range [0, 1]") do
@@ -15,7 +15,7 @@ describe("Random") do
 
     describe("with an Integer argument") do
       it("returns an Integer value") do
-        assert(Random.rand(500).type.to_s).equals("Integer")
+        assert(Random.rand(500)).is_a(Integer)
       end
 
       it("returns a value between 0 and the given maximum") do
@@ -26,7 +26,7 @@ describe("Random") do
 
     describe("with a Float argument") do
       it("returns a Float value") do
-        assert(Random.rand(500.0).type.to_s).equals("Float")
+        assert(Random.rand(500.0)).is_a(Float)
       end
 
       it("returns a value between 0 and the given maximum") do

--- a/spec/myst/type_spec.mt
+++ b/spec/myst/type_spec.mt
@@ -1,14 +1,146 @@
 require "stdlib/spec.mt"
 
-describe("Type#to_s") do
-  it("with a literal") do
-    assert({}.type.to_s).equals("Map")
-  end
-
-  it("with user defined type") do
-    deftype T
+describe("Type") do
+  describe(".to_s") do
+    it("with a literal") do
+      assert({}.type.to_s).equals("Map")
     end
 
-    assert(T.to_s).equals("T")
+    it("with user defined type") do
+      deftype T
+      end
+
+      assert(T.to_s).equals("T")
+    end
+
+    it("does not include the namespace of the type") do
+      defmodule Foo
+        deftype Bar
+        end
+      end
+
+      assert(Foo.Bar.to_s).equals("Bar")
+    end
+  end
+
+
+  describe(".==") do
+    deftype Type1; end
+    deftype Type2; end
+    deftype SubType1 : Type1; end
+    deftype SubType2 : Type1; end
+    defmodule Mod1; end
+
+    it("returns true for the same type") do
+      assert(Type1 == Type1).is_true
+    end
+
+    it("returns false for different types") do
+      assert(Type1 == Type2).is_false
+    end
+
+    it("returns false for a type and a subtype") do
+      assert(Type1 == SubType1).is_false
+    end
+
+    it("returns false for a type and a supertype") do
+      assert(SubType1 == Type1).is_false
+    end
+
+    it("returns false for different subtypes") do
+      assert(SubType1 == SubType2).is_false
+    end
+
+    it("returns false for a type and a module") do
+      assert(Type1 == Mod1).is_false
+    end
+  end
+
+
+  describe(".!=") do
+    deftype Type1; end
+    deftype Type2; end
+    deftype SubType1 : Type1; end
+    deftype SubType2 : Type1; end
+    defmodule Mod1; end
+
+    it("returns false for the same type") do
+      assert(Type1 != Type1).is_false
+    end
+
+    it("returns true for different types") do
+      assert(Type1 != Type2).is_true
+    end
+
+    it("returns true for a type and a subtype") do
+      assert(Type1 != SubType1).is_true
+    end
+
+    it("returns true for a type and a supertype") do
+      assert(SubType1 != Type1).is_true
+    end
+
+    it("returns true for different subtypes") do
+      assert(SubType1 != SubType2).is_true
+    end
+
+    it("returns true for a type and a module") do
+      assert(Type1 != Mod1).is_true
+    end
+  end
+
+  describe(".ancestors") do
+    defmodule Foo; end
+    defmodule Bar
+      include Foo
+    end
+
+    deftype RootType; end
+    deftype SubType1 : RootType; end
+    deftype SubType2 : SubType1
+      include Foo
+    end
+    deftype SubType3 : SubType1
+      include Bar
+    end
+    deftype SubType4 : SubType2; end
+
+    it("returns a List of the supertypes of the type") do
+      assert(RootType.ancestors).is_a(List)
+    end
+
+    it("does not include the type itself in the resulting list") do
+      assert(RootType.ancestors.any?{ |a| a == RootType }).is_false
+    end
+
+    it("includes the base Type") do
+      assert(RootType.ancestors).includes(Type)
+    end
+
+    it("is empty when called on Type") do
+      assert(Type.ancestors).equals([])
+    end
+
+    it("includes all supertypes of the type") do
+      assert(SubType1.ancestors).equals([RootType, Type])
+    end
+
+    it("does not include subtypes of the type") do
+      assert(RootType.ancestors.any?{ |a| a == SubType1 }).is_false
+    end
+
+#    # TODO: Re-add these when Module#== is implemented.
+#    it("includes the included modules for the type") do
+#      assert(SubType2.ancestors).includes(Foo)
+#    end
+#
+#    it("includes modules included by other included modules") do
+#      assert(SubType3.ancestors).includes(Bar)
+#      assert(SubType3.ancestors).includes(Foo)
+#    end
+#
+#    it("includes modules includes by supertypes") do
+#      assert(SubType4.ancestors).includes(Foo)
+#    end
   end
 end

--- a/src/myst/interpreter.cr
+++ b/src/myst/interpreter.cr
@@ -9,6 +9,7 @@ module Myst
     property scope_stack : Array(Scope)
     property callstack : Callstack
     property kernel : TModule
+    property base_type : TType
 
     property warnings : Int32
 
@@ -25,7 +26,10 @@ module Myst
       @stack = [] of MTValue
       @scope_stack = [] of Scope
       @callstack = Callstack.new
+      @kernel = TModule.new("Kernel")
+      @base_type = __make_type("Type", @kernel.scope, parent_type: nil)
       @kernel = create_kernel
+      init_base_type
       @self_stack = [@kernel] of MTValue
       @warnings = 0
     end
@@ -118,7 +122,7 @@ module Myst
 
 
     def put_error(error : RuntimeError)
-      value_to_s = __scopeof(error.value)["to_s"].as(TFunctor)
+      value_to_s = recursive_lookup(error.value, "to_s").as(TFunctor)
       result = Invocation.new(self, value_to_s, error.value, [] of MTValue, nil).invoke
       errput.puts("Uncaught Exception: " + result.as(String))
       errput.puts(error.trace)

--- a/src/myst/interpreter/kernel.cr
+++ b/src/myst/interpreter/kernel.cr
@@ -1,24 +1,23 @@
 module Myst
   class Interpreter
     def create_kernel : TModule
-      kernel = TModule.new("Kernel")
-      kernel.scope.clear
-      kernel = init_top_level(kernel)
-      kernel.scope["Kernel"]    = kernel
-      kernel.scope["Nil"]       = init_nil(kernel)
-      kernel.scope["Boolean"]   = init_boolean(kernel)
-      kernel.scope["Integer"]   = init_integer(kernel)
-      kernel.scope["Float"]     = init_float(kernel)
-      kernel.scope["String"]    = init_string(kernel)
-      kernel.scope["Symbol"]    = init_symbol(kernel)
-      kernel.scope["List"]      = init_list(kernel)
-      kernel.scope["Map"]       = init_map(kernel)
-      io_type = init_io(kernel)
-      kernel.scope["IO"]        = io_type
-      kernel.scope["TCPSocket"] = init_tcp_socket(kernel, io_type)
-      kernel.scope["Time"]      = init_time(kernel)
-      kernel.scope["Random"]    = init_random(kernel)
-      kernel
+      @kernel.scope.clear
+      init_top_level
+      @kernel.scope["Kernel"]   = @kernel
+      @kernel.scope["Nil"]       = init_nil
+      @kernel.scope["Boolean"]   = init_boolean
+      @kernel.scope["Integer"]   = init_integer
+      @kernel.scope["Float"]     = init_float
+      @kernel.scope["String"]    = init_string
+      @kernel.scope["Symbol"]    = init_symbol
+      @kernel.scope["List"]      = init_list
+      @kernel.scope["Map"]       = init_map
+      io_type = init_io
+      @kernel.scope["IO"]        = io_type
+      @kernel.scope["TCPSocket"] = init_tcp_socket(io_type)
+      @kernel.scope["Time"]      = init_time
+      @kernel.scope["Random"]    = init_random
+      @kernel
     end
   end
 end

--- a/src/myst/interpreter/kernel.cr
+++ b/src/myst/interpreter/kernel.cr
@@ -3,20 +3,21 @@ module Myst
     def create_kernel : TModule
       @kernel.scope.clear
       init_top_level
-      @kernel.scope["Kernel"]   = @kernel
-      @kernel.scope["Nil"]       = init_nil
-      @kernel.scope["Boolean"]   = init_boolean
-      @kernel.scope["Integer"]   = init_integer
-      @kernel.scope["Float"]     = init_float
-      @kernel.scope["String"]    = init_string
-      @kernel.scope["Symbol"]    = init_symbol
-      @kernel.scope["List"]      = init_list
-      @kernel.scope["Map"]       = init_map
+      @kernel.scope["Kernel"]     = @kernel
+      @kernel.scope["Type"]       = @base_type
+      @kernel.scope["Nil"]        = init_nil
+      @kernel.scope["Boolean"]    = init_boolean
+      @kernel.scope["Integer"]    = init_integer
+      @kernel.scope["Float"]      = init_float
+      @kernel.scope["String"]     = init_string
+      @kernel.scope["Symbol"]     = init_symbol
+      @kernel.scope["List"]       = init_list
+      @kernel.scope["Map"]        = init_map
       io_type = init_io
-      @kernel.scope["IO"]        = io_type
-      @kernel.scope["TCPSocket"] = init_tcp_socket(io_type)
-      @kernel.scope["Time"]      = init_time
-      @kernel.scope["Random"]    = init_random
+      @kernel.scope["IO"]         = io_type
+      @kernel.scope["TCPSocket"]  = init_tcp_socket(io_type)
+      @kernel.scope["Time"]       = init_time
+      @kernel.scope["Random"]     = init_random
       @kernel
     end
   end

--- a/src/myst/interpreter/native_lib.cr
+++ b/src/myst/interpreter/native_lib.cr
@@ -13,7 +13,7 @@ module Myst
     # Same as `call_func`, but the function to call is given as a name to
     # look up on the given receiver.
     def call_func_by_name(itr, receiver : MTValue, name : String, args : Array(MTValue))
-      func = itr.__scopeof(receiver)[name].as(TFunctor)
+      func = itr.recursive_lookup(receiver, name).as(TFunctor)
       Invocation.new(itr, func, receiver, args, nil).invoke
     end
 

--- a/src/myst/interpreter/native_lib/boolean.cr
+++ b/src/myst/interpreter/native_lib/boolean.cr
@@ -12,9 +12,8 @@ module Myst
       this != other
     end
 
-    def init_boolean(kernel : TModule)
-      boolean_type = TType.new("Boolean", kernel.scope)
-      boolean_type.instance_scope["type"] = boolean_type
+    def init_boolean
+      boolean_type = __make_type("Boolean", @kernel.scope)
 
       NativeLib.def_instance_method(boolean_type, :to_s,  :bool_to_s)
       NativeLib.def_instance_method(boolean_type, :==,    :bool_eq)

--- a/src/myst/interpreter/native_lib/file.cr
+++ b/src/myst/interpreter/native_lib/file.cr
@@ -110,9 +110,8 @@ module Myst
 
 
 
-    def init_file(kernel : TModule, fd_type : TType)
-      file_type = TType.new("File", kernel.scope, fd_type)
-      kernel.scope["File"] = file_type
+    def init_file(fd_type : TType)
+      file_type = __make_type("File", @kernel.scope, parent_type: fd_type)
 
       NativeLib.def_method(file_type, :basename,    :passthrough_File_basename)
       NativeLib.def_method(file_type, :chmod,       :passthrough_File_chmod)

--- a/src/myst/interpreter/native_lib/float.cr
+++ b/src/myst/interpreter/native_lib/float.cr
@@ -107,9 +107,8 @@ module Myst
       end
     end
 
-    def init_float(kernel : TModule)
-      float_type = TType.new("Float", kernel.scope)
-      float_type.instance_scope["type"] = float_type
+    def init_float
+      float_type = __make_type("Float", @kernel.scope)
 
       NativeLib.def_instance_method(float_type, :+,       :float_add)
       NativeLib.def_instance_method(float_type, :-,       :float_subtract)

--- a/src/myst/interpreter/native_lib/integer.cr
+++ b/src/myst/interpreter/native_lib/integer.cr
@@ -106,9 +106,8 @@ module Myst
       end
     end
 
-    def init_integer(kernel : TModule)
-      integer_type = TType.new("Integer", kernel.scope)
-      integer_type.instance_scope["type"] = integer_type
+    def init_integer
+      integer_type = __make_type("Integer", @kernel.scope)
 
       NativeLib.def_instance_method(integer_type, :+,     :int_add)
       NativeLib.def_instance_method(integer_type, :-,     :int_subtract)

--- a/src/myst/interpreter/native_lib/io.cr
+++ b/src/myst/interpreter/native_lib/io.cr
@@ -21,11 +21,13 @@ module Myst
       NativeLib.def_instance_method(io_type, :write, :io_write)
 
       fd_type = init_file_descriptor(io_type)
-      file_type = init_file(fd_type)
+      io_type.scope["FileDescriptor"] = fd_type
 
       @kernel.scope["STDIN"]    = make_io_fd(fd_type, 0)
       @kernel.scope["STDOUT"]   = make_io_fd(fd_type, 1)
       @kernel.scope["STDERR"]   = make_io_fd(fd_type, 2)
+
+      file_type = init_file(fd_type)
       @kernel.scope["File"]     = file_type
 
       io_type

--- a/src/myst/interpreter/native_lib/io.cr
+++ b/src/myst/interpreter/native_lib/io.cr
@@ -21,12 +21,12 @@ module Myst
       NativeLib.def_instance_method(io_type, :write, :io_write)
 
       fd_type = init_file_descriptor(io_type)
-
-      @kernel.scope["STDIN"]   = make_io_fd(fd_type, 0)
-      @kernel.scope["STDOUT"]  = make_io_fd(fd_type, 1)
-      @kernel.scope["STDERR"]  = make_io_fd(fd_type, 2)
-
       file_type = init_file(fd_type)
+
+      @kernel.scope["STDIN"]    = make_io_fd(fd_type, 0)
+      @kernel.scope["STDOUT"]   = make_io_fd(fd_type, 1)
+      @kernel.scope["STDERR"]   = make_io_fd(fd_type, 2)
+      @kernel.scope["File"]     = file_type
 
       io_type
     end

--- a/src/myst/interpreter/native_lib/io.cr
+++ b/src/myst/interpreter/native_lib/io.cr
@@ -14,19 +14,19 @@ module Myst
       fd
     end
 
-    def init_io(kernel : TModule)
-      io_type = TType.new("IO", kernel.scope)
+    def init_io
+      io_type = __make_type("IO", @kernel.scope)
 
       NativeLib.def_instance_method(io_type, :read, :io_read)
       NativeLib.def_instance_method(io_type, :write, :io_write)
 
-      fd_type = init_file_descriptor(kernel, io_type)
+      fd_type = init_file_descriptor(io_type)
 
-      kernel.scope["STDIN"]   = make_io_fd(fd_type, 0)
-      kernel.scope["STDOUT"]  = make_io_fd(fd_type, 1)
-      kernel.scope["STDERR"]  = make_io_fd(fd_type, 2)
+      @kernel.scope["STDIN"]   = make_io_fd(fd_type, 0)
+      @kernel.scope["STDOUT"]  = make_io_fd(fd_type, 1)
+      @kernel.scope["STDERR"]  = make_io_fd(fd_type, 2)
 
-      file_type = init_file(kernel, fd_type)
+      file_type = init_file(fd_type)
 
       io_type
     end

--- a/src/myst/interpreter/native_lib/io/file_descriptor.cr
+++ b/src/myst/interpreter/native_lib/io/file_descriptor.cr
@@ -24,9 +24,8 @@ module Myst
       TNil.new
     end
 
-    def init_file_descriptor(kernel : TModule, io_type : TType)
-      io_fd_type = TType.new("FileDescriptor", kernel.scope, io_type)
-      io_type.scope["FileDescriptor"] = io_fd_type
+    def init_file_descriptor(io_type : TType)
+      io_fd_type = __make_type("FileDescriptor", @kernel.scope, parent_type: io_type)
 
       NativeLib.def_instance_method(io_fd_type, :initialize,  :io_fd_init)
       NativeLib.def_instance_method(io_fd_type, :read,        :io_fd_read)

--- a/src/myst/interpreter/native_lib/io/file_descriptor.cr
+++ b/src/myst/interpreter/native_lib/io/file_descriptor.cr
@@ -25,7 +25,7 @@ module Myst
     end
 
     def init_file_descriptor(io_type : TType)
-      io_fd_type = __make_type("FileDescriptor", @kernel.scope, parent_type: io_type)
+      io_fd_type = __make_type("FileDescriptor", io_type.scope, parent_type: io_type)
 
       NativeLib.def_instance_method(io_fd_type, :initialize,  :io_fd_init)
       NativeLib.def_instance_method(io_fd_type, :read,        :io_fd_read)

--- a/src/myst/interpreter/native_lib/list.cr
+++ b/src/myst/interpreter/native_lib/list.cr
@@ -114,9 +114,8 @@ module Myst
       end
     end
 
-    def init_list(kernel : TModule)
-      list_type = TType.new("List", kernel.scope)
-      list_type.instance_scope["type"] = list_type
+    def init_list
+      list_type = __make_type("List", @kernel.scope)
 
       NativeLib.def_instance_method(list_type, :each,    :list_each)
       NativeLib.def_instance_method(list_type, :size,    :list_size)

--- a/src/myst/interpreter/native_lib/map.cr
+++ b/src/myst/interpreter/native_lib/map.cr
@@ -81,9 +81,8 @@ module Myst
       end
     end
 
-    def init_map(kernel : TModule)
-      map_type = TType.new("Map", kernel.scope)
-      map_type.instance_scope["type"] = map_type
+    def init_map
+      map_type = __make_type("Map", @kernel.scope)
 
       NativeLib.def_instance_method(map_type, :each, :map_each)
       NativeLib.def_instance_method(map_type, :size, :map_size)

--- a/src/myst/interpreter/native_lib/nil.cr
+++ b/src/myst/interpreter/native_lib/nil.cr
@@ -23,9 +23,8 @@ module Myst
     end
 
 
-    def init_nil(kernel : TModule)
-      nil_type = TType.new("Nil", kernel.scope)
-      nil_type.instance_scope["type"] = nil_type
+    def init_nil
+      nil_type = __make_type("Nil", @kernel.scope)
 
       NativeLib.def_instance_method(nil_type, :to_s,  :nil_to_s)
       NativeLib.def_instance_method(nil_type, :==,    :nil_eq)

--- a/src/myst/interpreter/native_lib/random.cr
+++ b/src/myst/interpreter/native_lib/random.cr
@@ -10,8 +10,8 @@ module Myst
       end
     end
 
-    def init_random(kernel : TModule)
-      random_module = TModule.new("Random", kernel.scope)
+    def init_random
+      random_module = TModule.new("Random", @kernel.scope)
 
       NativeLib.def_method(random_module, :rand, :random_rand)
 

--- a/src/myst/interpreter/native_lib/string.cr
+++ b/src/myst/interpreter/native_lib/string.cr
@@ -125,9 +125,8 @@ module Myst
       this.reverse
     end
 
-    def init_string(kernel : TModule)
-      string_type = TType.new("String", kernel.scope)
-      string_type.instance_scope["type"] = string_type
+    def init_string
+      string_type = __make_type("String", @kernel.scope)
 
       NativeLib.def_instance_method(string_type, :+,         :string_add)
       NativeLib.def_instance_method(string_type, :*,         :string_multiply)

--- a/src/myst/interpreter/native_lib/symbol.cr
+++ b/src/myst/interpreter/native_lib/symbol.cr
@@ -23,9 +23,8 @@ module Myst
     end
 
 
-    def init_symbol(kernel : TModule)
-      symbol_type = TType.new("Symbol", kernel.scope)
-      symbol_type.instance_scope["type"] = symbol_type
+    def init_symbol
+      symbol_type = __make_type("Symbol", @kernel.scope)
 
       NativeLib.def_instance_method(symbol_type, :to_s,  :symbol_to_s)
       NativeLib.def_instance_method(symbol_type, :==,    :symbol_eq)

--- a/src/myst/interpreter/native_lib/tcp_socket.cr
+++ b/src/myst/interpreter/native_lib/tcp_socket.cr
@@ -29,9 +29,8 @@ module Myst
       TNil.new
     end
 
-    def init_tcp_socket(kernel : TModule, io_type)
-      tcp_socket_type = TType.new("TCPSocket", kernel.scope, io_type)
-      tcp_socket_type.instance_scope["type"] = tcp_socket_type
+    def init_tcp_socket(io_type)
+      tcp_socket_type = __make_type("TCPSocket", @kernel.scope, parent_type: io_type)
 
       NativeLib.def_instance_method(tcp_socket_type, :initialize, :tcp_socket_init)
       NativeLib.def_instance_method(tcp_socket_type, :read,       :tcp_socket_read)

--- a/src/myst/interpreter/native_lib/time.cr
+++ b/src/myst/interpreter/native_lib/time.cr
@@ -22,9 +22,8 @@ module Myst
       end
     end
 
-    def init_time(kernel : TModule)
-      time_type = TType.new("Time", kernel.scope)
-      time_type.instance_scope["type"] = time_type
+    def init_time
+      time_type = __make_type("Time", @kernel.scope)
 
       NativeLib.def_method(time_type, :now, :static_time_now)
       NativeLib.def_instance_method(time_type, :to_s,  :time_to_s)

--- a/src/myst/interpreter/native_lib/top_level.cr
+++ b/src/myst/interpreter/native_lib/top_level.cr
@@ -16,11 +16,9 @@ module Myst
       TNil.new
     end
 
-    def init_top_level(kernel : TModule)
-      NativeLib.def_method(kernel, :exit, :mt_exit)
-      NativeLib.def_method(kernel, :sleep, :mt_sleep)
-
-      kernel
+    def init_top_level
+      NativeLib.def_method(@kernel, :exit, :mt_exit)
+      NativeLib.def_method(@kernel, :sleep, :mt_sleep)
     end
   end
 end

--- a/src/myst/interpreter/native_lib/type.cr
+++ b/src/myst/interpreter/native_lib/type.cr
@@ -30,6 +30,24 @@ module Myst
       this.to_s
     end
 
+    NativeLib.method :inst_eq, TInstance, other : MTValue do
+      case other
+      when TInstance
+        this == other
+      else
+        false
+      end
+    end
+
+    NativeLib.method :inst_not_eq, TInstance, other : MTValue do
+      case other
+      when TInstance
+        this != other
+      else
+        false
+      end
+    end
+
 
     def init_base_type
       NativeLib.def_method(@base_type, :to_s,       :static_type_to_s)
@@ -37,7 +55,9 @@ module Myst
       NativeLib.def_method(@base_type, :!=,         :static_type_not_eq)
       NativeLib.def_method(@base_type, :ancestors,  :static_type_ancestors)
 
-      NativeLib.def_instance_method(@base_type, :to_s,        :inst_to_s)
+      NativeLib.def_instance_method(@base_type, :to_s,    :inst_to_s)
+      NativeLib.def_instance_method(@base_type, :==,      :inst_eq)
+      NativeLib.def_instance_method(@base_type, :!=,      :inst_not_eq)
 
       @base_type
     end

--- a/src/myst/interpreter/native_lib/type.cr
+++ b/src/myst/interpreter/native_lib/type.cr
@@ -1,10 +1,10 @@
 module Myst
   class Interpreter
-    NativeLib.method :type_to_s, TType do
+    NativeLib.method :static_type_to_s, TType do
       this.name
     end
 
-    NativeLib.method :type_eq, TType, other : MTValue do
+    NativeLib.method :static_type_eq, TType, other : MTValue do
       case other
       when TType
         this == other
@@ -13,7 +13,7 @@ module Myst
       end
     end
 
-    NativeLib.method :type_not_eq, TType, other : MTValue do
+    NativeLib.method :static_type_not_eq, TType, other : MTValue do
       case other
       when TType
         this != other
@@ -22,11 +22,22 @@ module Myst
       end
     end
 
+    NativeLib.method :static_type_ancestors, TType do
+      TList.new(this.ancestors.map(&.as(MTValue)))
+    end
+
+    NativeLib.method :inst_to_s, TInstance do
+      this.to_s
+    end
+
 
     def init_base_type
-      NativeLib.def_method(@base_type, :to_s,  :type_to_s)
-      NativeLib.def_method(@base_type, :==,    :type_eq)
-      NativeLib.def_method(@base_type, :!=,    :type_not_eq)
+      NativeLib.def_method(@base_type, :to_s,       :static_type_to_s)
+      NativeLib.def_method(@base_type, :==,         :static_type_eq)
+      NativeLib.def_method(@base_type, :!=,         :static_type_not_eq)
+      NativeLib.def_method(@base_type, :ancestors,  :static_type_ancestors)
+
+      NativeLib.def_instance_method(@base_type, :to_s,        :inst_to_s)
 
       @base_type
     end

--- a/src/myst/interpreter/native_lib/type.cr
+++ b/src/myst/interpreter/native_lib/type.cr
@@ -1,0 +1,34 @@
+module Myst
+  class Interpreter
+    NativeLib.method :type_to_s, TType do
+      this.name
+    end
+
+    NativeLib.method :type_eq, TType, other : MTValue do
+      case other
+      when TType
+        this == other
+      else
+        false
+      end
+    end
+
+    NativeLib.method :type_not_eq, TType, other : MTValue do
+      case other
+      when TType
+        this != other
+      else
+        true
+      end
+    end
+
+
+    def init_base_type
+      NativeLib.def_method(@base_type, :to_s,  :type_to_s)
+      NativeLib.def_method(@base_type, :==,    :type_eq)
+      NativeLib.def_method(@base_type, :!=,    :type_not_eq)
+
+      @base_type
+    end
+  end
+end

--- a/src/myst/interpreter/nodes/literals.cr
+++ b/src/myst/interpreter/nodes/literals.cr
@@ -42,7 +42,7 @@ module Myst
         else
           visit(piece)
           expr_result = stack.pop
-          value_to_s = __scopeof(expr_result)["to_s"].as(TFunctor)
+          value_to_s = recursive_lookup(expr_result, "to_s").as(TFunctor)
           result = Invocation.new(
             self,
             value_to_s,

--- a/src/myst/interpreter/nodes/type_def.cr
+++ b/src/myst/interpreter/nodes/type_def.cr
@@ -18,10 +18,10 @@ module Myst
             end
             typ
           else
-            nil
+            @base_type
           end
 
-        type = TType.new(node.name, current_scope, supertype: supertype)
+        type = __make_type(node.name, current_scope, supertype)
         current_scope.assign(node.name, type)
       end
 

--- a/src/myst/interpreter/nodes/unary_ops.cr
+++ b/src/myst/interpreter/nodes/unary_ops.cr
@@ -3,7 +3,7 @@ module Myst
     def visit(node : Negation)
       visit(node.value)
       value = stack.pop()
-      negate = self.__scopeof(value)["negate"].as(TFunctor)
+      negate = recursive_lookup(value, "negate").as(TFunctor)
       result = Invocation.new(self, negate, value, [] of MTValue, nil).invoke
       stack.push(result)
     end
@@ -13,7 +13,7 @@ module Myst
       value = stack.pop()
 
       result =
-        if not_method = self.__scopeof(value)["!"]?
+        if not_method = self.recursive_lookup(value, "!")
           not_method = not_method.as(TFunctor)
           Invocation.new(self, not_method, value, [] of MTValue , nil).invoke
         else

--- a/src/myst/interpreter/scope.cr
+++ b/src/myst/interpreter/scope.cr
@@ -57,5 +57,11 @@ module Myst
 
     # Remove all values from this scope. Parent scopes are not affected.
     delegate each, clear, to: @values
+
+    def inspect(io : IO)
+      io << "<<Scope(#{@values.inspect} parent="
+      @parent.inspect(io)
+      io << ")>>"
+    end
   end
 end

--- a/src/myst/interpreter/util.cr
+++ b/src/myst/interpreter/util.cr
@@ -90,21 +90,21 @@ module Myst
     # The method will return `nil` if no matching entry is found.
     def recursive_lookup(receiver, name, check_current = true)
       func = current_scope[name] if check_current && current_scope.has_key?(name)
-      if func.nil?
+      unless func
         func = __scopeof(receiver)[name]?
       end
 
-      if func.nil?
+      unless func
         case receiver
         when TType
-          func ||= receiver.extended_ancestors.each do |anc|
-            unless (found = __scopeof(anc)[name]?).nil?
+          func = receiver.extended_ancestors.each do |anc|
+            if found = __scopeof(anc)[name]?
               break found
             end
           end
         else
-          func ||= __typeof(receiver).ancestors.each do |anc|
-            unless (found = __scopeof(anc, prefer_instance_scope: true)[name]?).nil?
+          func = __typeof(receiver).ancestors.each do |anc|
+            if found = __scopeof(anc, prefer_instance_scope: true)[name]?
               break found
             end
           end
@@ -119,7 +119,7 @@ module Myst
       type_name = __typeof(value).name
       error_message = "No variable or method `#{name}` for #{type_name}"
 
-      if value_to_s = __scopeof(value)["to_s"]?
+      if value_to_s = recursive_lookup(value, "to_s")
         value_str = NativeLib.call_func_by_name(self, value, "to_s", [] of MTValue)
         error_message = "No variable or method `#{name}` for #{value_str}:#{type_name}"
       end

--- a/src/myst/interpreter/util.cr
+++ b/src/myst/interpreter/util.cr
@@ -63,6 +63,14 @@ module Myst
       end
     end
 
+    # Create a new, fully initialized TType object. This takes care of setting
+    # the lexical scope, inheriting from the base type and more.
+    def __make_type(name : String, lexical_scope : Scope?, parent_type = @base_type)
+      typ = TType.new(name, parent_type, lexical_scope)
+      typ.instance_scope["type"] = typ
+      typ
+    end
+
 
     # Lookup a value under the given name in the current scope or one of its
     # ancestors. If the value is not found, a `No variable or method`

--- a/src/myst/interpreter/value.cr
+++ b/src/myst/interpreter/value.cr
@@ -88,17 +88,28 @@ module Myst
     property! supertype      : TType?
     property  extended_modules = [] of TModule
 
-    def initialize(@name : String, parent : Scope?=nil, @supertype : TType? = nil)
+    def initialize(@name : String, @supertype : TType?, parent : Scope?=nil)
       @scope = Scope.new(parent)
       @instance_scope = Scope.new(parent)
       # TODO: revist this when base object for TType is in place
       # Currently this prevents to_s from being overriden on Types
-      @scope["to_s"] = TFunctor.new("to_s", [
-        ->ttype_to_s(MTValue, Array(MTValue), TFunctor?)] of Callable)
+      # @scope["to_s"] = TFunctor.new("to_s", [
+      #     ->ttype_to_s(MTValue, Array(MTValue), TFunctor?)] of Callable)
+      # @scope["=="] = TFunctor.new("==", [
+      #     ->ttype_eq(MTValue, Array(MTValue), TFunctor?)] of Callable)
     end
 
     def ttype_to_s(_a, _b, _c)
       @name.as(MTValue)
+    end
+
+    def ttype_eq(_a, args, _c)
+      case other = args[0]
+      when TType
+        self == other
+      else
+        false
+      end.as(MTValue)
     end
 
     def type_name

--- a/src/myst/interpreter/value.cr
+++ b/src/myst/interpreter/value.cr
@@ -80,6 +80,12 @@ module Myst
     end
 
     def_equals_and_hash scope
+
+    def inspect(io : IO)
+      io << "%#{@name}("
+      @scope.inspect(io)
+      io << ")"
+    end
   end
 
   class TType < ContainerType
@@ -91,25 +97,6 @@ module Myst
     def initialize(@name : String, @supertype : TType?, parent : Scope?=nil)
       @scope = Scope.new(parent)
       @instance_scope = Scope.new(parent)
-      # TODO: revist this when base object for TType is in place
-      # Currently this prevents to_s from being overriden on Types
-      # @scope["to_s"] = TFunctor.new("to_s", [
-      #     ->ttype_to_s(MTValue, Array(MTValue), TFunctor?)] of Callable)
-      # @scope["=="] = TFunctor.new("==", [
-      #     ->ttype_eq(MTValue, Array(MTValue), TFunctor?)] of Callable)
-    end
-
-    def ttype_to_s(_a, _b, _c)
-      @name.as(MTValue)
-    end
-
-    def ttype_eq(_a, args, _c)
-      case other = args[0]
-      when TType
-        self == other
-      else
-        false
-      end.as(MTValue)
     end
 
     def type_name
@@ -149,6 +136,14 @@ module Myst
     end
 
     def_equals_and_hash name, scope, instance_scope
+
+    def inspect(io : IO)
+      io << "##{@name}(static="
+      @scope.inspect(io)
+      io << ", instance="
+      @instance_scope.inspect(io)
+      io << ")"
+    end
   end
 
   class TInstance < MutableValue
@@ -168,6 +163,12 @@ module Myst
     end
 
     def_equals_and_hash type, scope
+
+    def to_s(io : IO)
+      io << "<##{type_name} "
+      @ivars.inspect(io)
+      io << ">"
+    end
   end
 
   class TNil < MutableValue
@@ -304,5 +305,13 @@ module Myst
     end
 
     def_equals_and_hash name, clauses, lexical_scope
+
+    def inspect(io : IO)
+      if closure?
+        io << "&&#{name}/#{clauses.size}"
+      else
+        io << "&#{name}/#{clauses.size}"
+      end
+    end
   end
 end

--- a/stdlib/assert.mt
+++ b/stdlib/assert.mt
@@ -204,6 +204,29 @@ defmodule Assert
     def >(other)
       greater_than(other)
     end
+
+    # is_a(type) -> self
+    #
+    # Assert that the value is an instance of `type`.
+    def is_a(other : Type)
+      unless [@value.type, *@value.type.ancestors].any?{ |anc| anc == other }
+        raise %AssertionFailure{
+          "<(@value.type)> (<(@value.ancestors.map{ |t| t.to_s }.join(","))>)",
+          other,
+          "value is not an instance or subtype of <(other)>"
+        }
+      end
+    end
+
+    # includes(element) -> self
+    #
+    # Assert that the value includes `element`. This requires that the value is
+    # Enumerable (implements `#each`)
+    def includes(element)
+      unless @value.any?{ |e| e == element }
+        raise %AssertionFailure{@value, element, "value does not include the requested element"}
+      end
+    end
   end
 
 

--- a/stdlib/file.mt
+++ b/stdlib/file.mt
@@ -1,10 +1,10 @@
 # File extends IO.FileDescriptor, but is initialized in the native library,
 # so the extension is not repeated here.
 deftype File
-  defstatic open(name : String); open(name, "r"); end
   defstatic open(name : String, mode)
     %File{name, mode}
   end
+  defstatic open(name : String); open(name, "r"); end
 
   def path; @path; end
   def mode; @mode; end


### PR DESCRIPTION
This PR introduces a base type (called `Type`) that all other types inherit from. This type allows for common functionality such as `.to_s` or `==` to be naively implemented for _all_ instances and types, and also allows Myst code to add functionality to every type/instance in the program (note that, unlike Ruby, modules are _not_ types, so this functionality is not (yet) implemented for modules).

Other additions and changes in this commit were included to get the code to compile and successfully pass tests:
- [interpreter] use `recursive_lookup` everywhere possible when looking for functions
- [interpreter, nativelib] add `__make_type` utility to ensure new types always inherit the base type, reference the Kernel scope, and have a `.type` property.
- [stdlib] add `Assertion.is_a` for testing type restriction and `Assertion.includes` for elemental inclusion.
- [interpreter] add `@base_type` interpreter property.
- [nativelib] always reference `@kernel` when creating new native library types.
- [interpreter] implement `inspect` for various Value types to improve error output when lookups fail (`TType`, `TInstance`, `TModule`, `TFunctor`, and `Scope`).

A nice effect of this PR is that we can finally get rid of this hackiness:

https://github.com/myst-lang/myst/blob/d2bcada926ecdd3a763685c2022a9254ffec033c/src/myst/interpreter/value.cr#L94-L97