### PR TITLE
General documentation updates.

### DIFF
--- a/stdlib/assert.mt
+++ b/stdlib/assert.mt
@@ -1,3 +1,28 @@
+#doc Assert
+#| The `Assert` module provides an interface for making assertions about Myst
+#| code and values.
+#|
+#| Interacting with this module is primarily done through the top-level
+#| `assert` method, providing either a value or code block to use as the
+#| subject of the assertions. This method wraps that value or code block into
+#| an assertion object (either `Assertion` or `BlockAssertion`), which is then
+#| used to actually perform the assertions.
+#|
+#| This module is designed with a fluid interface to simplify writing multiple
+#| assertions on the same subject. Every assertion method returns `self` when
+#| it succeeds or raises an Error when it fails, meaning assertions can easily
+#| be chained together.
+#|
+#| As a contrived example, `assert().between(a, b)` could also be written as
+#| two separate assertions chained together:
+#| `assert().greater_or_equal(a).less_or_equal(b)`.
+#|
+#| This module is primarily intended for use with the `Spec` module to write
+#| tests, but it also available for use by application code in cases where
+#| complex assertions about data are needed. That said, the language itself
+#| often provides cleaner, more idiomatic ways of making similar assertions
+#| that should be preferred (e.g. pattern matching, multiple function clauses,
+#| `match` expressions, etc.).
 defmodule Assert
   #doc AssertionFailure
   #| An AssertionFailure is a container object that is raised when an assertion

--- a/stdlib/assert.mt
+++ b/stdlib/assert.mt
@@ -310,13 +310,22 @@ end
 
 
 
-#doc assert(&block?) -> assertion object
-#| The global entrypoint to writing assertions. `assert` accepts any value or
-#| block as an argument, and returns the appropriate assertion object to write
-#| assertions with.
+#doc assert(value) -> assertion
+#| The global entrypoint to writing assertions about objects. This clause
+#| accepts any value as an argument, and returns an `Assertion` object to use
+#| for executing assertions about that object.
 def assert(value)
   %Assert.Assertion{value}
 end
+#doc assert(&block) -> block assertion
+#| The global entrypoint for writing assertions about blocks of code. This
+#| clause accepts a block argument containing the code to test and returns a
+#| `BlockAssertion` object to use for setting up calls and making assertions
+#| about the block of code.
+#|
+#| This clause also accepts function captures of pre-defined methods:
+#|
+#| `assert(&Foo.might_raise!).called_with_arguments(1, 2).raises(:some_error)`
 def assert(&block)
   %Assert.BlockAssertion{block}
 end

--- a/stdlib/colored.mt
+++ b/stdlib/colored.mt
@@ -1,3 +1,15 @@
+#doc Color
+#| A library for colorizing terminal output using ANSI control sequences.
+#|
+#| This library provides a single method, `colored`, which accepts a content
+#| object and the name of a color as a symbol, and returns a new String
+#| containing ANSI control sequences for setting terminal colors.
+#|
+#| Note that the ANSI color codes are not absolute. Depending on the user's
+#| terminal settings, the actual colors displayed in the terminal when using a
+#| given color code may not match the color implied by the name. For example,
+#| many dark terminal themes swap the black and white colors to better
+#| accomodate most use cases. Keep this in mind when selecting colors to use.
 defmodule Color
   ANSI_RESET  = "\e[0m"
 
@@ -24,8 +36,18 @@ defmodule Color
     end
   end
 
-  def colored(string, sym : Symbol)
-    color = ansi_from_symbol(sym)
-    "<(color)><(string)><(ANSI_RESET)>"
+  #doc colored(content, color : Symbol) -> string
+  #| Returns a new String with the given content wrapped between two ANSI
+  #| control sequences for setting the colors of the terminal. The first
+  #| sequence sets the terminal to the color specified by `color`, and the
+  #| second resets the terminal to its original colors.
+  #|
+  #| If `content` is not already a String, it will be converted to a String
+  #| via interpolation (i.e., by calling `to_s` on it).
+  #|
+  #| This method may raise an error if `color` is not a valid color name.
+  def colored(content, color : Symbol)
+    color = ansi_from_symbol(color)
+    "<(color)><(content)><(ANSI_RESET)>"
   end
 end

--- a/stdlib/enumerable.mt
+++ b/stdlib/enumerable.mt
@@ -1,3 +1,10 @@
+#doc Enumerable
+#| The Enumerable module provides various methods for interacting with
+#| collections of values. Both `List` and `Map` include this module by default.
+#|
+#| The only requirement for including this module is to define an `each` method
+#| that accepts a block argument and calls that block for every element of the
+#| collection.
 defmodule Enumerable
   #doc map(&block) -> list
   #| Call `block` for each element of `self` and collect the result for each
@@ -30,7 +37,7 @@ defmodule Enumerable
 
   #doc size -> integer
   #| Returns the size of the enumerable, as determined by the number of
-  #| elements yielded by `each`.
+  #| times `each` yields an element to its block.
   def size
     counter = 0
 
@@ -103,7 +110,8 @@ defmodule Enumerable
   end
 
   #doc min -> element
-  #| Returns the element with the lowest value as determined by <.
+  #| Returns the element with the lowest value as determined by comparing
+  #| values with their `<` operator.
   def min
     value = nil
 
@@ -117,7 +125,8 @@ defmodule Enumerable
   end
 
   #doc max -> element
-  #| Returns the element with the highest value as determined by >.
+  #| Returns the element with the highest value as determined by comparing
+  #| values with their `>` operator.
   def max
     value = nil
 
@@ -131,7 +140,7 @@ defmodule Enumerable
   end
 
   #doc sort -> list
-  #| Returns a sorted list of all elements.
+  #| Returns a new, sorted List of all elements in the enumerable.
   def sort
     list = to_list
     when size < 2
@@ -157,7 +166,7 @@ defmodule Enumerable
   end
 
   #doc to_list -> list
-  #| Returns a list containing all elements.
+  #| Returns a new List containing all elements of the enumerable.
   def to_list
     list = []
 
@@ -168,15 +177,14 @@ defmodule Enumerable
     list
   end
 
-  #doc reduce(value=nil, &block) -> element
-  #| For every element in the enumerable, call block with the result of the
+  #doc reduce(&block) -> value
+  #| For every element in the enumerable, call `block` with the result of the
   #| previous call and the current element as arguments. Returns a single
-  #| value.
+  #| value: the result of the final call to `block`.
   #|
-  #| If an initial value is given, it will be used as the accumulator
-  #| argument for the block call with the first element. If an initial value is
-  #| not given, the first element will not be passed to the block and will be
-  #| be used as the accumulator for the block call with the second element.
+  #| For the first element of the enumerable, the block is _not_ called, and
+  #| the element is instead passed directly as the first argument of the
+  #| `block` call for the second element.
   def reduce(&block)
     value = nil
 
@@ -190,6 +198,9 @@ defmodule Enumerable
 
     value
   end
+  #doc reduce(value, &block) -> value
+  #| Use `value` as the initial value for the accumulator instead of the first
+  #| element, allowing `block` to be called for the first element as well.
   def reduce(value, &block)
     each do |e|
       value = block(value, e)

--- a/stdlib/spec.mt
+++ b/stdlib/spec.mt
@@ -11,15 +11,18 @@ include Spec
 #| `it`, providing either a name, a code block to test, or both. Multiple `it`s
 #| can be organized under a `describe` block for better visual clarity.
 #|
-#| The Spec library operates primarily through `assert`. Each spec can make
-#| multiple calls to `assert`, with an argument that is expected to be truthy.
-#| If the given argument is not truthy, the spec is considered failed, and the
-#| suite will not pass.
+#| When running an `it` spec, it is considered a "pass" so long as the given
+#| block runs without raising an unhandled error. If an error does propogate
+#| to outside of the `it` block, the spec is considered "failed".
 #|
-#| By default, a passing assertion will output a green `.` to the terminal,
-#| while a failing assertion will output a red `F`. For now, execution will
-#| immediately halt on the first assertion failure, and the program will exit
-#| with a non-zero status code.
+#| Specs are often best written using an assertion library (such as the
+#| standard library's `Assert` module) to remove boilerplate and better express
+#| the intention of each spec.
+#|
+#| By default, a passing spec will output a green `.` to the terminal, while a
+#| failing spec will output a red `F`. For now, execution will immediately halt
+#| on the first assertion failure, and the program will exit with a non-zero
+#| status code.
 defmodule Spec
   describe_stack = []
 


### PR DESCRIPTION
Every Kernel-level object should now have _some_ documentation. Specifically, this adds module documentation for `Color`, `Enumerable`, and `Assert`, as well as expanded documentation for the different clauses of the top-level `assert` method.