### PR TITLE
Fixes #183. Add newline after ParseError messages

### DIFF
--- a/src/myst/syntax/exceptions.cr
+++ b/src/myst/syntax/exceptions.cr
@@ -27,6 +27,7 @@ module Myst
         <<-MESSAGE
         ParseError at #{@location}
           #{@message}
+
         MESSAGE
       )
     end


### PR DESCRIPTION
All ParseError messages should now end with a newline to avoid showing the prompt on the same line.
![screen shot 2018-04-17 at 3 52 00 pm](https://user-images.githubusercontent.com/783733/38893092-4ad56cc2-4257-11e8-9b7f-abb7a3e45ede.png)
