### PR TITLE
Fixes #184. Don't show warning output when running specs.

### DIFF
--- a/spec/interpreter/nodes/op_assign_spec.cr
+++ b/spec/interpreter/nodes/op_assign_spec.cr
@@ -86,7 +86,7 @@ describe "Interpreter - OpAssign" do
     end
 
     it "assigns new underscores" do
-      itr = parse_and_interpret %q(
+      itr = interpret_with_mocked_output %q(
         _a ||= 1
         _a
       )
@@ -199,7 +199,7 @@ describe "Interpreter - OpAssign" do
     end
 
     it "assigns new underscores as nil" do
-      itr = parse_and_interpret %q(
+      itr = interpret_with_mocked_output %q(
         _a &&= 1
         _a
       )

--- a/spec/interpreter/nodes/underscore_spec.cr
+++ b/spec/interpreter/nodes/underscore_spec.cr
@@ -3,14 +3,28 @@ require "../../support/nodes.cr"
 require "../../support/interpret.cr"
 
 describe "Interpreter - Underscore" do
-  it_interprets %q(_ = 1; _),         [val(1)]
-  it_interprets %q(_a = _b = {}; _b), [TMap.new]
+  it "acts like a normal variable for assignment" do
+    itr = interpret_with_mocked_output %q(_ = 1; _)
+    itr.stack.last.should eq(val(1))
+  end
 
-  # Underscore reference UTs
-  ## Continue parsing. It's only a warning, prg must compile and return value
-  it_interprets %q(_a = 1;_b = 2;_c = 1 + 2; _c), [val(3)]
-  ## Simply test for number of warnings
-  it_warns %q(_a = 1;_b = 2;_c = 5 + _b;), 1
-  it_warns %q(_a = 1;_b = 2;_c = _a + _b;), 2
+  it "displays a warning when referenced" do
+    itr = interpret_with_mocked_output %q(_a = 1;_b = 2;_c = 1 + 2; _c)
+    itr.errput.to_s.should match(/Reference to an underscore value `_c`/)
+  end
+
+  it "does not fail when referenced" do
+    itr = interpret_with_mocked_output %q(_a = 1;_b = 2;_c = 1 + 2; _c)
+    itr.stack.last.should eq(val(3))
+  end
+
+  # The displayed warning should explain that an underscore should not be referenced.
+  it_warns %q(_a = 1;_b = 2;_c = 5 + _b;), /WARNING: Reference to an underscore value `_b`
+Underscores indicate that a variable should not be referenced.
+If this reference is intentional, consider removing the leading `_`./
+
+  it_warns %q(_a = 1;_b = 2;_c = _a + _b;), /WARNING: Reference to an underscore value `_a`
+Underscores indicate that a variable should not be referenced.
+If this reference is intentional, consider removing the leading `_`./
 end
 

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -1,10 +1,6 @@
 require "spec"
 require "../src/myst/**"
 
-# An environment variable to be able to test if we're running in
-# unit tests or in production (prod. declaration in src/myst.cr)
-ENV["MYST_ENV"] = "test"
-
 include Myst
 
 # Run the Myst parser on the given source code, returning the AST that the

--- a/spec/support/interpret.cr
+++ b/spec/support/interpret.cr
@@ -75,10 +75,8 @@ end
 # equal to expected
 def it_warns(source, expected, file=__FILE__, line=__LINE__, end_line=__END_LINE__)
   it "raises warning from `#{source}`", file, line, end_line do
-    interpreter=Interpreter.new
-    program = parse_program(source)
-    interpreter.run(program)
-    interpreter.warnings.should eq expected
+    itr = interpret_with_mocked_output(source)
+    itr.errput.to_s.should match(expected)
   end
 end
 

--- a/src/myst/interpreter.cr
+++ b/src/myst/interpreter.cr
@@ -128,10 +128,8 @@ module Myst
 
     def warn(message : String, node : Node)
       @warnings += 1
-      unless ENV["MYST_ENV"] == "test"
-        errput.puts("WARNING: #{message}")
-        errput.puts("  from `#{node.name}` at #{node.location.to_s}")
-      end
+      errput.puts("WARNING: #{message}")
+      errput.puts("  from `#{node.name}` at #{node.location.to_s}")
     end
 
 

--- a/src/myst/vm.cr
+++ b/src/myst/vm.cr
@@ -10,10 +10,6 @@ module Myst
     def initialize(source : IO = IO::Memory.new, *, source_name : String = "eval_input", with_stdlib? : Bool = true,
                    use_stdios? : Bool = false, product? : Bool = true)
 
-      # Just telling warn() we're not in test mode (test  declaration in
-      # spec/spec_helper.cr)
-      ENV["MYST_ENV"] = product? ? "prod" : "test"
-
       @interpreter = Interpreter.new
       @semantic_visitor = Semantic::Visitor.new
 


### PR DESCRIPTION
The specs no longer output `WARNING` messages about referencing underscores.

The root issue that caused this was that the VM was almost always setting `ENV["MYST_ENV"] = "prod"`, which would screw up tests that ran later in the pipeline, since they weren't resetting the variable.

Part of this PR is removing `MYST_ENV` from the interpreter. The same behavior that it was implementing has been possible using `interpret_with_mocked_output` for quite a while now, so it makes sense to be consistent with it.

In general, using environment variables for configuring the interpreter should be avoided. Instead (especially since the VM is embeddable in any crystal projects), this should be done with flags on the interpreter that can also be set through the CLI. This gives much finer control over execution and isolates instances of the interpreter from the global state of environment variables.