### PR TITLE
Use `context` instead of nested `it`s to fix breaking changes in Crystal .27.1

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-crystal 0.27.0
+crystal 0.27.2

--- a/shard.yml
+++ b/shard.yml
@@ -1,6 +1,6 @@
 name: myst
 version: 0.6.2
-crystal: 0.27.0
+crystal: 0.27.2
 license: MIT
 authors:
   - Jon Egeland <jonegeland@gmail.com>

--- a/spec/interpreter/nodes/op_assign_spec.cr
+++ b/spec/interpreter/nodes/op_assign_spec.cr
@@ -19,7 +19,7 @@ describe "Interpreter - OpAssign" do
         itr.errput.to_s.downcase.should match(/no variable or method `a`/)
       end
 
-      it "does not allow re-assignment to constants" do
+      context "does not allow re-assignment to constants" do
         it_does_not_interpret %Q(
           THING = 1
           THING #{op} 2

--- a/spec/interpreter/nodes/require_spec.cr
+++ b/spec/interpreter/nodes/require_spec.cr
@@ -64,7 +64,7 @@ Dir.cd(__DIR__) do
       itr.stack.pop.should eq(val(true))
     end
 
-    it "must be given a String value as a path" do
+    context "must be given a String value as a path" do
       it_does_not_interpret %q(
         require true
       )

--- a/spec/interpreter/nodes/simple_assign_spec.cr
+++ b/spec/interpreter/nodes/simple_assign_spec.cr
@@ -26,7 +26,7 @@ describe "Interpreter - SimpleAssign" do
     interpreter.current_scope["THING"].should eq(val(2))
   end
 
-  it "does not allow re-assignment to constants" do
+  context "does not allow re-assignment to constants" do
     it_does_not_interpret %q(
       THING = 1
       THING = 2

--- a/spec/interpreter/nodes/unary_ops_spec.cr
+++ b/spec/interpreter/nodes/unary_ops_spec.cr
@@ -3,19 +3,19 @@ require "../../support/nodes.cr"
 require "../../support/interpret.cr"
 
 describe "Interpreter - OpUnary" do
-  it "handle negation for integers" do
+  context "handle negation for integers" do
     it_interprets %q(a = 2 + -1; a), [val(1)]
     it_interprets %q(a = -2 + -1;), [val(-3)]
     it_interprets %q(a = -2; -a), [val(2)]
   end
   
-  it "handle negation for floats" do
+  context "handle negation for floats" do
     it_interprets %q(-2.23 + 1), [val(-1.23)]
     it_interprets %q(-2.23 + 1.1), [val(-1.13)]
     it_interprets %q(a = 2.23; -a), [val(-2.23)]
   end
 
-  it "handle not for booleans" do
+  context "handle not for booleans" do
     it_interprets %q(!true), [val(false)]
     it_interprets %q(a=false; b = !a; b), [val(true)]
   end


### PR DESCRIPTION
As of Crystal .27.1 nested `it`'s are no longer allowed (https://github.com/crystal-lang/crystal/pull/7297), and it raises at runtime. The breaking change affects 6 of our `it`'s, hence the specs are broken. 

This PR simply changes the parent `it`'s to `describe`'s which fixes the problem.